### PR TITLE
fix typos and grammatical errors in README and CONTRIBUTING files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
 # Contributing to `govultr`
 
-We would love to get your feedback, thoughts, and overall improvements to `govultr`! 
+We would love to get your feedback, thoughts, and overall improvements to `govultr`!
 
 ## Overview
 
-- All Code should run through `go fmt`
+- All code should run through `go fmt`
 - All code **must be tested**
 - All types, structs, and funcs **must be documented** for GoDocs
 
@@ -15,40 +15,41 @@ GoVultr supports `go modules` so you can pull down the repo outside of your `$GO
 You can also run:
 `go get -u github.com/vultr/govultr`
 
-
 ## Testing
-We aim to have as much code coverage as possible. 
 
-To run tests locally :
+We aim to have as much code coverage as possible.
+
+To run tests locally:
+
 ```sh
 go test .
 ```
 
-If you want to get more information on your local unit tests. You can run the following
+If you want to get more information on your local unit tests. You can run the following:
 
 ```sh
 go test -v -coverprofile cover.out
 go tool cover -html=cover.out
 ```
 
-Upon a Pull Request we have CodeCov checks to make sure that code coverage meets a minimum requirement. In addition to CodeCov we have Travis-CI that will run your unit tests on each pull request as well.
+Upon opening a pull request we have CodeCov checks to make sure that code coverage meets a minimum requirement. In addition to CodeCov we have Travis CI that will run your unit tests on each pull request as well.
 
-## Versioning 
+## Versioning
 
-GoVultr follows [SemVer](http://semver.org/) for versioning. New functionality will result in a increment to the minor version. While, 
-bug fixes will result in a increment to the patch version. 
+GoVultr follows [SemVer](http://semver.org/) for versioning. New functionality will result in a increment to the minor version and bug fixes will result in a increment to the patch version.
 
 ## Releases
-Releases of new versions are done as their independent pull requests - They will also be done by the maintainers.
 
-To release a new version of `govultr` we must do the following.
+Releases of new versions are done as independent pull requests and will be made by the maintainers.
+
+To release a new version of `govultr` we must do the following:
 
 - Update version number in `govultr.go` to reflect the new release version
-- Make the appropriate updates to `CHANGELOG.md`. This should include the 
-    - Version, 
-    - List of fix/features with accompanying pull request ID
-    - Description of each fix/feature
-    
+- Make the appropriate updates to `CHANGELOG.md`. This should include the:
+  - Version,
+  - List of fix/features with accompanying pull request ID
+  - Description of each fix/feature
+
 ```
 ## v0.0.1 (2019-05-05)
 
@@ -58,5 +59,6 @@ To release a new version of `govultr` we must do the following.
 ### Features
 * BareMetalServer functionality #13
 ```
-- Submit a pull request with the following changes
-- Once the pull request is merged in - create a new tag and publish.
+
+- Submit a pull request with the changes above.
+- Once the pull request is merged in, create a new tag and publish.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 The official Vultr Go client - GoVultr allows you to interact with the Vultr V1 API.
 
 ## Installation
-```sh 
+
+```sh
 go get -u github.com/vultr/govultr
 ```
 
@@ -17,22 +18,22 @@ go get -u github.com/vultr/govultr
 Vultr uses a PAT (Personal Access token) to interact/authenticate with the APIs. An API Key can be generated and acquired from the API menu in [settings](https://my.vultr.com/settings/#settingsapi).
 
 To instantiate a govultr client you invoke `NewClient()`.
- 
-This takes in two parameters 
-- *http.Client
-- API Key  
 
-You can define your own `http.Client` however if you pass in `nil` then you will be defaulted to use `http.DefaultClient`
+This takes in two parameters:
 
-As for the API Key - We recommend you store this as a environmental variable and not hard code it.
+- \*http.Client
+- API Key
 
+You can define your own `http.Client` however if you pass in `nil` then you will be defaulted to use `http.DefaultClient`. For the API key, we recommend you store this as a environment variable and not hard code it.
 
-There are also three parameters you may change regarding the client
+There are also three optional parameters you may change regarding the client:
+
 - BaseUrl: allows you to override the base URL that Vultr defaults to
 - UserAgent: allows you to override the UserAgent that Vultr defaults to
 - RateLimit: Vultr currently rate limits how fast you can make calls back to back. This lets you configure if you want a delay in between calls
 
-### Example client setup 
+### Example Client Setup
+
 ```go
 package main
 
@@ -43,9 +44,9 @@ import (
 
 func main() {
 	apiKey := os.Getenv("VultrAPIKey")
-	
+
 	vultrClient := govultr.NewClient(nil, apiKey)
-	
+
 	// Optional changes
 	_ = vultrClient.SetBaseURL("https://api.vultr.com")
 	vultrClient.SetUserAgent("mycool-app")
@@ -54,7 +55,9 @@ func main() {
 ```
 
 ### Example Usage
+
 Create a VPS
+
 ```go
 vpsOptions := &govultr.ServerOptions{
 	Label:                "awesome-go-app",
@@ -72,17 +75,20 @@ if err != nil {
 }
 ```
 
-
 ## Versioning
+
 This project follows [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/vultr/govultr/tags).
 
 ## Documentation
-For detailed information about our V1 API head over to our [API documentation](https://www.vultr.com/api/) 
 
-Want more details about this clients functionality then checkout our [GoDoc](https://godoc.org/github.com/vultr/govultr) documentation.
+For detailed information about our V1 API head over to our [API documentation](https://www.vultr.com/api/).
+
+If you want more details about this client's functionality then check out our [GoDoc](https://godoc.org/github.com/vultr/govultr) documentation.
 
 ## Contributing
+
 Feel free to send pull requests our way! Please see the [contributing guidelines](CONTRIBUTING.md).
 
 ## License
+
 This project is licensed under the MIT License - see the [LICENSE.md](LICENSE) file for details.


### PR DESCRIPTION
- Standardized spacing after headers.
- Fixed typos in README.md.
- Added some clarification in grammar used in CONTRIBUTING.md and README.md to improve clarity. 