### PR TITLE
removing go 1.10 and adding 1.13 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: go
 
 go:
-  - 1.10.x
   - 1.11.x
   - 1.12.x
+  - 1.13.x
   - tip
 
 matrix:


### PR DESCRIPTION
## Description
Go 1.13 has been released. Dropping support for go 1.10 and updating travis-ci

## Related Issues
none

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
