### PR TITLE
Retry rate-limited requests with exponential backoff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 
 go:
-  - 1.11.x
   - 1.12.x
   - 1.13.x
   - tip

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/vultr/govultr
 
 go 1.12
+
+require github.com/hashicorp/go-retryablehttp v0.6.3

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
+github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/hashicorp/go-retryablehttp v0.6.3 h1:tuulM+WnToeqa05z83YLmKabZxrySOmJAd4mJ+s2Nfg=
+github.com/hashicorp/go-retryablehttp v0.6.3/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/govultr.go
+++ b/govultr.go
@@ -103,6 +103,7 @@ func NewClient(httpClient *http.Client, key string) *Client {
 	}
 
 	client.client.HTTPClient = httpClient
+	client.client.Logger = nil
 	client.SetRetryLimit(retryLimit)
 	client.SetRateLimit(rateLimit)
 

--- a/govultr.go
+++ b/govultr.go
@@ -261,6 +261,10 @@ func (c *Client) SetRetryLimit(n int) {
 }
 
 func (c *Client) vultrErrorHandler(resp *http.Response, err error, numTries int) (*http.Response, error) {
+	if resp == nil {
+		return nil, fmt.Errorf("gave up after %d attempts, last error unavailable (resp == nil)", c.client.RetryMax+1)
+	}
+
 	buf, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("gave up after %d attempts, last error unavailable (error reading response body: %v)", c.client.RetryMax+1, err)

--- a/govultr_test.go
+++ b/govultr_test.go
@@ -43,10 +43,6 @@ func TestNewClient(t *testing.T) {
 		t.Errorf("NewClient BaseURL = %v, expected %v", client.BaseURL, server.URL)
 	}
 
-	if client.RateLimit == 0 || client.RateLimit.String() != "600ms" {
-		t.Errorf("NewClient RateLimit = %v, expected %v", client.RateLimit, rateLimit.String())
-	}
-
 	if client.APIKey.key != "dummy-key" {
 		t.Errorf("NewClient ApiKey = %v, expected %v", client.APIKey.key, "dummy-key")
 	}
@@ -228,8 +224,8 @@ func TestClient_SetRateLimit(t *testing.T) {
 	time := 600 * time.Millisecond
 	client.SetRateLimit(time)
 
-	if client.RateLimit != time {
-		t.Errorf("NewClient RateLimit = %v, expected %v", client.RateLimit, time)
+	if client.client.RetryWaitMax != time {
+		t.Errorf("NewClient max RateLimit = %v, expected %v", client.client.RetryWaitMax, time)
 	}
 }
 
@@ -273,5 +269,16 @@ func TestClient_OnRequestCompleted(t *testing.T) {
 	expected := `{"Vultr":"bird"}`
 	if !strings.Contains(completedRes, expected) {
 		t.Errorf("expected response to contain %v, Response = %v", expected, completedRes)
+	}
+}
+
+func TestClient_SetRetryLimit(t *testing.T) {
+	setup()
+	defer teardown()
+
+	client.SetRetryLimit(4)
+
+	if client.client.RetryMax != 4 {
+		t.Errorf("NewClient RateLimit = %v, expected %v", client.client.RetryMax, 4)
 	}
 }

--- a/govultr_test.go
+++ b/govultr_test.go
@@ -113,10 +113,8 @@ func TestClient_DoWithContextFailure(t *testing.T) {
 
 	err := client.DoWithContext(context.Background(), req, nil)
 
-	expected := `{Error}`
-
-	if !reflect.DeepEqual(err.Error(), expected) {
-		t.Fatalf("DoWithContext(): %v: expected %v", err, expected)
+	if !strings.Contains(err.Error(), "gave up after") || !strings.Contains(err.Error(), "last error") {
+		t.Fatalf("DoWithContext(): %v: expected 'gave up after ..., last error ...'", err)
 	}
 }
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
Implements exponential backoff for rate-limited requests to deal with low API rate-limit.

Based on #27. Still not the cleanest code, but is the bare minimum to implement retry correctly. See https://github.com/vultr/govultr/pull/27#pullrequestreview-311920776. I will be submitting another PR with a lot more refactoring when I have time.

## Related Issues
closes #26, closes #27

### Checklist:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [X] Have you linted your code locally prior to submission?
* [X] Have you successfully ran tests with your changes locally?
