### PR TITLE
DNS Record Update Priority

### DIFF
--- a/dns_records.go
+++ b/dns_records.go
@@ -27,7 +27,7 @@ type DNSRecord struct {
 	Type     string `json:"type"`
 	Name     string `json:"name"`
 	Data     string `json:"data"`
-	Priority int    `json:"priority"`
+	Priority *int   `json:"priority"`
 	TTL      int    `json:"ttl"`
 }
 
@@ -130,8 +130,8 @@ func (d *DNSRecordsServiceHandler) Update(ctx context.Context, domain string, dn
 	if dnsRecord.TTL != 0 {
 		values.Add("ttl", strconv.Itoa(dnsRecord.TTL))
 	}
-	if dnsRecord.Priority != 0 {
-		values.Add("priority", strconv.Itoa(dnsRecord.Priority))
+	if dnsRecord.Priority != nil {
+		values.Add("priority", strconv.Itoa(*dnsRecord.Priority))
 	}
 
 	req, err := d.client.NewRequest(ctx, http.MethodPost, uri, values)

--- a/dns_records_test.go
+++ b/dns_records_test.go
@@ -51,10 +51,10 @@ func TestDNSRecordsServiceHandler_List(t *testing.T) {
 	if err != nil {
 		t.Errorf("DNSRecord.List returned %+v, expected %+v", err, nil)
 	}
-
+	p := 0
 	expected := []DNSRecord{
-		{Type: "A", Name: "", Data: "127.0.0.1", Priority: 0, RecordID: 1265276, TTL: 300},
-		{Type: "A", Name: "", Data: "127.0.0.1", Priority: 0, RecordID: 1265276, TTL: 300},
+		{Type: "A", Name: "", Data: "127.0.0.1", Priority: &p, RecordID: 1265276, TTL: 300},
+		{Type: "A", Name: "", Data: "127.0.0.1", Priority: &p, RecordID: 1265276, TTL: 300},
 	}
 
 	if !reflect.DeepEqual(records, expected) {
@@ -70,13 +70,13 @@ func TestDNSRecordsServiceHandler_Update(t *testing.T) {
 
 		fmt.Fprint(writer)
 	})
-
+	p := 10
 	params := &DNSRecord{
 		RecordID: 14283638,
 		Name:     "api",
 		Data:     "turnip.data",
 		TTL:      120,
-		Priority: 10,
+		Priority: &p,
 	}
 
 	err := client.DNSRecord.Update(ctx, "turnip.services", params)


### PR DESCRIPTION
## Description

This will fix a bug in which you were not able to update the priority of a record to 0. It will introduce a backwards breaking change since now priority in the DNS Records struct will be a pointer to an int.

## Related Issues


### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
