### PR TITLE
remove encoding for user data input

### DIFF
--- a/bare_metal_server.go
+++ b/bare_metal_server.go
@@ -767,11 +767,9 @@ func (b *BareMetalServerServiceHandler) SetTag(ctx context.Context, serverID, ta
 func (b *BareMetalServerServiceHandler) SetUserData(ctx context.Context, serverID, userData string) error {
 	uri := "/v1/baremetal/set_user_data"
 
-	encodedUserData := base64.StdEncoding.EncodeToString([]byte(userData))
-
 	values := url.Values{
 		"SUBID":    {serverID},
-		"userdata": {encodedUserData},
+		"userdata": {userData},
 	}
 
 	req, err := b.client.NewRequest(ctx, http.MethodPost, uri, values)

--- a/bare_metal_server_test.go
+++ b/bare_metal_server_test.go
@@ -854,7 +854,7 @@ func TestBareMetalServerServiceHandler_SetUserData(t *testing.T) {
 		fmt.Fprint(writer)
 	})
 
-	err := client.BareMetalServer.SetUserData(ctx, "900000", "user-test-data")
+	err := client.BareMetalServer.SetUserData(ctx, "900000", "ZWNobyBIZWxsbyBXb3JsZA==")
 
 	if err != nil {
 		t.Errorf("Server.SetUserData return %+v ", err)

--- a/server.go
+++ b/server.go
@@ -790,11 +790,9 @@ func (s *ServerServiceHandler) SetUserData(ctx context.Context, instanceID, user
 
 	uri := "/v1/server/set_user_data"
 
-	encodedUserData := base64.StdEncoding.EncodeToString([]byte(userData))
-
 	values := url.Values{
 		"SUBID":    {instanceID},
-		"userdata": {encodedUserData},
+		"userdata": {userData},
 	}
 
 	req, err := s.client.NewRequest(ctx, http.MethodPost, uri, values)

--- a/server_test.go
+++ b/server_test.go
@@ -452,7 +452,7 @@ func TestServerServiceHandler_SetUserData(t *testing.T) {
 		fmt.Fprint(writer)
 	})
 
-	err := client.Server.SetUserData(ctx, "1234", "user-test-data")
+	err := client.Server.SetUserData(ctx, "1234", "ZWNobyBIZWxsbyBXb3JsZA==")
 
 	if err != nil {
 		t.Errorf("Server.SetUserData return %+v ", err)


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
Removes the userdata encoding on govultr side and allows instead for the vultr api to error handle if an unencoded string is passed. Affects baremetal userdata and instance user data

## Related Issues
Supports #71

### Checklist:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you linted your code locally prior to submission?
* [ ] Have you successfully ran tests with your changes locally?
