### PR TITLE
change param name for bm to match instances

### DIFF
--- a/bare_metal_server.go
+++ b/bare_metal_server.go
@@ -74,7 +74,7 @@ type BareMetalReq struct {
 	SSHKeyIDs       []string `json:"sshkey_id,omitempty"`
 	AppID           int      `json:"app_id,omitempty"`
 	UserData        string   `json:"user_data,omitempty"`
-	NotifyActivate  bool     `json:"notify_activate,omitempty"`
+	ActivationEmail bool     `json:"activation_email,omitempty"`
 	Hostname        string   `json:"hostname,omitempty"`
 	Tag             string   `json:"tag,omitempty"`
 	ReservedIPv4    string   `json:"reserved_ipv4,omitempty"`

--- a/bare_metal_server_test.go
+++ b/bare_metal_server_test.go
@@ -116,7 +116,7 @@ func TestBareMetalServerServiceHandler_Create(t *testing.T) {
 		SSHKeyIDs:       []string{"6b80207b1821f"},
 		AppID:           1,
 		UserData:        "echo Hello World",
-		NotifyActivate:  true,
+		ActivationEmail: true,
 		Hostname:        "test",
 		Tag:             "go-test",
 		ReservedIPv4:    "111.111.111.111",


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
Use same param name for activation emails in bare metal and instances

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
