### PR TITLE
v2 - lb removing enable sticky sessions param

### DIFF
--- a/load_balancer.go
+++ b/load_balancer.go
@@ -84,8 +84,7 @@ type GenericInfo struct {
 
 // StickySessions represents cookie for your load balancer
 type StickySessions struct {
-	StickySessionsEnabled string `json:"sticky_sessions,omitempty"`
-	CookieName            string `json:"cookie_name,omitempty"`
+	CookieName string `json:"cookie_name,omitempty"`
 }
 
 // ForwardingRules represent a list of forwarding rules


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
Remove field `stickySessionsEnabled` from the stickysession struct in LBs. This is no longer needed in v2

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
