### PR TITLE
Remove base64 encoding of user data on create

### DIFF
--- a/bare_metal_server.go
+++ b/bare_metal_server.go
@@ -2,7 +2,6 @@ package govultr
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -342,7 +341,7 @@ func (b *BareMetalServerServiceHandler) Create(ctx context.Context, regionID, pl
 			values.Add("APPID", options.AppID)
 		}
 		if options.UserData != "" {
-			values.Add("userdata", base64.StdEncoding.EncodeToString([]byte(options.UserData)))
+			values.Add("userdata", options.UserData)
 		}
 		if options.NotifyActivate != "" {
 			values.Add("notify_activate", options.NotifyActivate)

--- a/bare_metal_server_test.go
+++ b/bare_metal_server_test.go
@@ -142,7 +142,7 @@ func TestBareMetalServerServiceHandler_Create(t *testing.T) {
 		Label:           "go-bm-test",
 		SSHKeyIDs:       []string{"6b80207b1821f"},
 		AppID:           "1",
-		UserData:        "echo Hello World",
+		UserData:        "ZWNobyBIZWxsbyBXb3JsZAo=",
 		NotifyActivate:  "yes",
 		Hostname:        "test",
 		Tag:             "go-test",

--- a/server.go
+++ b/server.go
@@ -2,7 +2,6 @@ package govultr
 
 import (
 	"context"
-	"encoding/base64"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -1349,7 +1348,7 @@ func (s *ServerServiceHandler) Create(ctx context.Context, regionID, vpsPlanID, 
 		}
 
 		if options.UserData != "" {
-			values.Add("userdata", base64.StdEncoding.EncodeToString([]byte(options.UserData)))
+			values.Add("userdata", options.UserData)
 		}
 
 		if options.NotifyActivate == true {

--- a/server_test.go
+++ b/server_test.go
@@ -790,7 +790,7 @@ func TestServerServiceHandler_Create(t *testing.T) {
 		EnableIPV6:           true,
 		EnablePrivateNetwork: true,
 		AutoBackups:          true,
-		UserData:             "uno-dos-tres",
+		UserData:             "dW5vLWRvcy10cmVzCg==",
 		NotifyActivate:       true,
 		DDOSProtection:       true,
 		SnapshotID:           "12ab",


### PR DESCRIPTION
## Description
Don't not base64 encode userdata on server and bare-metal creation. This matches behaviour from #73.

## Related Issues
 - [terraform-provider-vultr #68](https://github.com/vultr/terraform-provider-vultr/issues/68)

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
