### PR TITLE
Plans Update : adding disk_count

### DIFF
--- a/plans.go
+++ b/plans.go
@@ -27,6 +27,7 @@ type BareMetalPlan struct {
 	CPUThreads  int      `json:"cpu_threads"`
 	RAM         int      `json:"ram"`
 	Disk        int      `json:"disk"`
+	DiskCount   int      `json:"disk_count"`
 	Bandwidth   int      `json:"bandwidth"`
 	MonthlyCost int      `json:"monthly_cost"`
 	Type        string   `json:"type"`
@@ -39,6 +40,7 @@ type Plan struct {
 	VCPUCount   int      `json:"vcpu_count"`
 	RAM         int      `json:"ram"`
 	Disk        int      `json:"disk"`
+	DiskCount   int      `json:"disk_count"`
 	Bandwidth   int      `json:"bandwidth"`
 	MonthlyCost int      `json:"monthly_cost"`
 	Type        string   `json:"type"`

--- a/plans_test.go
+++ b/plans_test.go
@@ -12,7 +12,7 @@ func TestPlanServiceHandler_List(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/plans", func(writer http.ResponseWriter, request *http.Request) {
-		response := `{ "plans":[{ "id": "vc2-16c-64gb", "vcpu_count": 16, "ram": 65536, "disk": 1280, "bandwidth": 10240, "monthly_cost": 320, "type": "vc2", "locations": [  "dfw"]}], "meta": { "total": 19, "links": { "next": "", "prev": "" } }}`
+		response := `{ "plans":[{ "id": "vc2-16c-64gb", "vcpu_count": 16, "ram": 65536, "disk": 1280, "disk_count": 1, "bandwidth": 10240, "monthly_cost": 320, "type": "vc2", "locations": [  "dfw"]}], "meta": { "total": 19, "links": { "next": "", "prev": "" } }}`
 		fmt.Fprint(writer, response)
 	})
 
@@ -27,6 +27,7 @@ func TestPlanServiceHandler_List(t *testing.T) {
 			VCPUCount:   16,
 			RAM:         65536,
 			Disk:        1280,
+			DiskCount:   1,
 			Bandwidth:   10240,
 			MonthlyCost: 320.00,
 			Type:        "vc2",
@@ -54,7 +55,7 @@ func TestPlanServiceHandler_GetBareMetalList(t *testing.T) {
 	setup()
 	defer teardown()
 	mux.HandleFunc("/v2/plans-metal", func(writer http.ResponseWriter, request *http.Request) {
-		response := `{ "plans_metal":[{"id": "vbm-4c-32gb","cpu_count": 4,"cpu_threads": 8,"cpu_model": "E3-1270v6","ram": 32768,"disk": 240,"bandwidth": 5120,"monthly_cost": 300,"type": "SSD", "locations": [ "dwf"]}], "meta": { "total": 19, "links": { "next": "", "prev": "" } }}`
+		response := `{ "plans_metal":[{"id": "vbm-4c-32gb","cpu_count": 4,"cpu_threads": 8,"cpu_model": "E3-1270v6","ram": 32768,"disk": 240, "disk_count": 1, "bandwidth": 5120,"monthly_cost": 300,"type": "SSD", "locations": [ "dwf"]}], "meta": { "total": 19, "links": { "next": "", "prev": "" } }}`
 		fmt.Fprint(writer, response)
 	})
 
@@ -71,6 +72,7 @@ func TestPlanServiceHandler_GetBareMetalList(t *testing.T) {
 			CPUThreads:  8,
 			RAM:         32768,
 			Disk:        240,
+			DiskCount:   1,
 			Bandwidth:   5120,
 			MonthlyCost: 300,
 			Type:        "SSD",


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
The field `disk_count` was added to all plans for instances and baremetal. This denotes how many disks are available with the plan

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
