### PR TITLE
Update 'Create a VPS' usage sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ Create a VPS
 instanceOptions := &govultr.InstanceCreateReq{
   Label:                "awesome-go-app",
   Hostname:             "awesome-go.com",
-  Backups:              true,
-  EnableIPv6:           true,
+  Backups:              "enabled",
+  EnableIPv6:           BoolToBoolPtr(false),
   OsID:                 362,
   Plan:                 "vc2-1c-2gb",   
   Region:               "ewr",


### PR DESCRIPTION
## Description
This PR updates the **Create a VPS** sample in the project README file to utilise what I believe to be correct syntax for the V2 Vultr Go client.  

**Note**: I am using the goVultr API as a learning tool to learn go, as such I am unfamiliar with go syntax/idioms. 

When using the sample, I found the following issues.

Creating an instance requires a `InstanceCreateReq` struct to be passed into the call to `Create` rather than `InstanceReq` struct

https://github.com/vultr/govultr/blob/019c4d29bf308a32888c6b93094925f69164c281/instance.go#L251

The `Backups` property on `InstanceCreateReq` appears to be a `string` rather than `bool` 

https://github.com/vultr/govultr/blob/019c4d29bf308a32888c6b93094925f69164c281/instance.go#L226

The `EnableIPv6` property on `InstanceCreateReq` appears to be a pointer to a `bool` rather than `bool` 

https://github.com/vultr/govultr/blob/019c4d29bf308a32888c6b93094925f69164c281/instance.go#L222

## Related Issues
N/A 

### Checklist:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [X] Have you linted your code locally prior to submission?
* [X] Have you successfully ran tests with your changes locally?
