### PR TITLE
Instances : ListPrivateNetworks missing paging ability

### DIFF
--- a/instance.go
+++ b/instance.go
@@ -33,7 +33,7 @@ type InstanceService interface {
 	GetBandwidth(ctx context.Context, instanceID string) (*Bandwidth, error)
 	GetNeighbors(ctx context.Context, instanceID string) (*Neighbors, error)
 
-	ListPrivateNetworks(ctx context.Context, instanceID string) ([]PrivateNetwork, *Meta, error)
+	ListPrivateNetworks(ctx context.Context, instanceID string, options *ListOptions) ([]PrivateNetwork, *Meta, error)
 	AttachPrivateNetwork(ctx context.Context, instanceID, networkID string) error
 	DetachPrivateNetwork(ctx context.Context, instanceID, networkID string) error
 
@@ -459,12 +459,19 @@ func (i *InstanceServiceHandler) GetNeighbors(ctx context.Context, instanceID st
 }
 
 // ListPrivateNetworks currently attached to an instance.
-func (i *InstanceServiceHandler) ListPrivateNetworks(ctx context.Context, instanceID string) ([]PrivateNetwork, *Meta, error) {
+func (i *InstanceServiceHandler) ListPrivateNetworks(ctx context.Context, instanceID string, options *ListOptions) ([]PrivateNetwork, *Meta, error) {
 	uri := fmt.Sprintf("%s/%s/private-networks", instancePath, instanceID)
 	req, err := i.client.NewRequest(ctx, http.MethodGet, uri, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+
+	newValues, err := query.Values(options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req.URL.RawQuery = newValues.Encode()
 
 	networks := new(privateNetworksBase)
 	if err = i.client.DoWithContext(ctx, req, networks); err != nil {

--- a/instance_test.go
+++ b/instance_test.go
@@ -105,7 +105,7 @@ func TestServerServiceHandler_ListPrivateNetworks(t *testing.T) {
 		fmt.Fprint(writer, response)
 	})
 
-	privateNetwork, meta, err := client.Instance.ListPrivateNetworks(ctx, "14b3e7d6-ffb5-4994-8502-57fcd9db3b33")
+	privateNetwork, meta, err := client.Instance.ListPrivateNetworks(ctx, "14b3e7d6-ffb5-4994-8502-57fcd9db3b33", nil)
 	if err != nil {
 		t.Errorf("Instance.ListPrivateNetworks return %+v, ", err)
 	}

--- a/instance_test.go
+++ b/instance_test.go
@@ -105,7 +105,11 @@ func TestServerServiceHandler_ListPrivateNetworks(t *testing.T) {
 		fmt.Fprint(writer, response)
 	})
 
-	privateNetwork, meta, err := client.Instance.ListPrivateNetworks(ctx, "14b3e7d6-ffb5-4994-8502-57fcd9db3b33", nil)
+	options := &ListOptions{
+		PerPage: 1,
+		Cursor:  "",
+	}
+	privateNetwork, meta, err := client.Instance.ListPrivateNetworks(ctx, "14b3e7d6-ffb5-4994-8502-57fcd9db3b33", options)
 	if err != nil {
 		t.Errorf("Instance.ListPrivateNetworks return %+v, ", err)
 	}


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
The `listPrivateNetworks` call allows for paging on the API and we return the metadata in the go library. However, you can't pass in paging information to the function. This adds paging ability

## Related Issues
n/a

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
