### PR TITLE
Backup Schedule : pointers on fields

### DIFF
--- a/govultr.go
+++ b/govultr.go
@@ -235,11 +235,15 @@ func (c *Client) vultrErrorHandler(resp *http.Response, err error, numTries int)
 
 // BoolToBoolPtr helper function that returns a pointer from your bool value
 func BoolToBoolPtr(value bool) *bool {
-	b := value
-	return &b
+	return &value
 }
 
 // StringToStringPtr helper function that returns a pointer from your string value
 func StringToStringPtr(value string) *string {
+	return &value
+}
+
+// IntToIntPtr helper function that returns a pointer from your string value
+func IntToIntPtr(value int) *int {
 	return &value
 }

--- a/instance.go
+++ b/instance.go
@@ -162,9 +162,9 @@ type BackupSchedule struct {
 // BackupScheduleReq struct used to create a backup schedule for an instance.
 type BackupScheduleReq struct {
 	Type string `json:"type"`
-	Hour int    `json:"hour,omitempty"`
-	Dow  int    `json:"dow,omitempty"`
-	Dom  int    `json:"dom,omitempty"`
+	Hour *int   `json:"hour,omitempty"`
+	Dow  *int   `json:"dow,omitempty"`
+	Dom  *int   `json:"dom,omitempty"`
 }
 
 // RestoreReq struct used to supply whether a restore should be from a backup or snapshot.

--- a/instance.go
+++ b/instance.go
@@ -164,7 +164,7 @@ type BackupScheduleReq struct {
 	Type string `json:"type"`
 	Hour *int   `json:"hour,omitempty"`
 	Dow  *int   `json:"dow,omitempty"`
-	Dom  *int   `json:"dom,omitempty"`
+	Dom  int    `json:"dom,omitempty"`
 }
 
 // RestoreReq struct used to supply whether a restore should be from a backup or snapshot.

--- a/instance_test.go
+++ b/instance_test.go
@@ -46,9 +46,9 @@ func TestServerServiceHandler_SetBackupSchedule(t *testing.T) {
 
 	bs := &BackupScheduleReq{
 		Type: "weekly",
-		Hour: 22,
-		Dow:  2,
-		Dom:  3,
+		Hour: IntToIntPtr(22),
+		Dow:  IntToIntPtr(2),
+		Dom:  IntToIntPtr(3),
 	}
 
 	if err := client.Instance.SetBackupSchedule(ctx, "14b3e7d6-ffb5-4994-8502-57fcd9db3b33", bs); err != nil {

--- a/instance_test.go
+++ b/instance_test.go
@@ -48,7 +48,7 @@ func TestServerServiceHandler_SetBackupSchedule(t *testing.T) {
 		Type: "weekly",
 		Hour: IntToIntPtr(22),
 		Dow:  IntToIntPtr(2),
-		Dom:  IntToIntPtr(3),
+		Dom:  3,
 	}
 
 	if err := client.Instance.SetBackupSchedule(ctx, "14b3e7d6-ffb5-4994-8502-57fcd9db3b33", bs); err != nil {


### PR DESCRIPTION


## Description
Backup Schedules allow the use of `0` as a valid field for Hour + Day of week. Changing these fields in the struct to be pointers to int.

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
