### PR TITLE
Instance : add optional fields for reinstall call

### DIFF
--- a/instance.go
+++ b/instance.go
@@ -22,7 +22,7 @@ type InstanceService interface {
 	Start(ctx context.Context, instanceID string) error
 	Halt(ctx context.Context, instanceID string) error
 	Reboot(ctx context.Context, instanceID string) error
-	Reinstall(ctx context.Context, instanceID string, reinstallReq *ReinstallReq) error
+	Reinstall(ctx context.Context, instanceID string, reinstallReq *ReinstallReq) (*Instance, error)
 
 	MassStart(ctx context.Context, instanceList []string) error
 	MassHalt(ctx context.Context, instanceList []string) error
@@ -252,7 +252,7 @@ type InstanceUpdateReq struct {
 
 // ReinstallReq struct used to allow changes during a reinstall
 type ReinstallReq struct {
-	Hostname string `json:"hostname"`
+	Hostname string `json:"hostname,omitempty"`
 }
 
 // Create will create the server with the given parameters
@@ -372,15 +372,19 @@ func (i *InstanceServiceHandler) Reboot(ctx context.Context, instanceID string) 
 }
 
 // Reinstall an instance.
-func (i *InstanceServiceHandler) Reinstall(ctx context.Context, instanceID string, reinstallReq *ReinstallReq) error {
+func (i *InstanceServiceHandler) Reinstall(ctx context.Context, instanceID string, reinstallReq *ReinstallReq) (*Instance, error) {
 	uri := fmt.Sprintf("%s/%s/reinstall", instancePath, instanceID)
 
 	req, err := i.client.NewRequest(ctx, http.MethodPost, uri, reinstallReq)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return i.client.DoWithContext(ctx, req, nil)
+	instance := new(instanceBase)
+	if err := i.client.DoWithContext(ctx, req, instance); err != nil {
+		return nil, err
+	}
+	return instance.Instance, nil
 }
 
 // MassStart will start a list of instances the machine is already running, it will be restarted.

--- a/instance.go
+++ b/instance.go
@@ -22,7 +22,7 @@ type InstanceService interface {
 	Start(ctx context.Context, instanceID string) error
 	Halt(ctx context.Context, instanceID string) error
 	Reboot(ctx context.Context, instanceID string) error
-	Reinstall(ctx context.Context, instanceID string) error
+	Reinstall(ctx context.Context, instanceID string, reinstallReq *ReinstallReq) error
 
 	MassStart(ctx context.Context, instanceList []string) error
 	MassHalt(ctx context.Context, instanceList []string) error
@@ -250,6 +250,11 @@ type InstanceUpdateReq struct {
 	FirewallGroupID      string   `json:"firewall_group_id,omitempty"`
 }
 
+// ReinstallReq struct used to allow changes during a reinstall
+type ReinstallReq struct {
+	Hostname string `json:"hostname"`
+}
+
 // Create will create the server with the given parameters
 func (i *InstanceServiceHandler) Create(ctx context.Context, instanceReq *InstanceCreateReq) (*Instance, error) {
 	uri := fmt.Sprintf("%s", instancePath)
@@ -367,10 +372,10 @@ func (i *InstanceServiceHandler) Reboot(ctx context.Context, instanceID string) 
 }
 
 // Reinstall an instance.
-func (i *InstanceServiceHandler) Reinstall(ctx context.Context, instanceID string) error {
+func (i *InstanceServiceHandler) Reinstall(ctx context.Context, instanceID string, reinstallReq *ReinstallReq) error {
 	uri := fmt.Sprintf("%s/%s/reinstall", instancePath, instanceID)
 
-	req, err := i.client.NewRequest(ctx, http.MethodPost, uri, nil)
+	req, err := i.client.NewRequest(ctx, http.MethodPost, uri, reinstallReq)
 	if err != nil {
 		return err
 	}

--- a/instance_test.go
+++ b/instance_test.go
@@ -459,7 +459,7 @@ func TestServerServiceHandler_Reinstall(t *testing.T) {
 		fmt.Fprint(writer)
 	})
 
-	err := client.Instance.Reinstall(ctx, "14b3e7d6-ffb5-4994-8502-57fcd9db3b33")
+	err := client.Instance.Reinstall(ctx, "14b3e7d6-ffb5-4994-8502-57fcd9db3b33", nil)
 
 	if err != nil {
 		t.Errorf("Instance.Reinstall returned %+v", err)

--- a/instance_test.go
+++ b/instance_test.go
@@ -456,13 +456,79 @@ func TestServerServiceHandler_Reinstall(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/v2/instances/14b3e7d6-ffb5-4994-8502-57fcd9db3b33/reinstall", func(writer http.ResponseWriter, request *http.Request) {
-		fmt.Fprint(writer)
+		response := `{
+			"instance": {
+				"id": "14b3e7d6-ffb5-4994-8502-57fcd9db3b33",
+				"os": "CentOS SELinux 8 x64",
+				"ram": 2048,
+				"disk": 60,
+				"main_ip": "123.123.123.123",
+				"vcpu_count": 2,
+				"region": "ewr",
+				"plan": "vc2-1c-2gb",
+				"date_created": "2013-12-19 14:45:41",
+				"status": "active",
+				"allowed_bandwidth": 2000,
+				"netmask_v4": "255.255.255.248",
+				"gateway_v4": "123.123.123.1",
+				"power_status": "running",
+				"server_status": "ok",
+				"v6_network": "2001:DB8:1000::",
+				"v6_main_ip": "fd11:1111:1112:1c02:0200:00ff:fe00:0000",
+				"v6_network_size": 64,
+				"label": "my new server",
+				"internal_ip": "10.99.0.10",
+				"kvm": "https://my.vultr.com/subs/novnc/api.php?data=eawxFVZw2mXnhGUV",
+				"default_password" : "nreqnusibni",
+				"tag": "tagger",
+				"os_id": 362,
+				"app_id": 0,
+				"firewall_group_id": "1234",
+				"features": [
+					"auto_backups", "ipv6"
+				]
+			}
+		}`
+		fmt.Fprint(writer, response)
 	})
 
-	err := client.Instance.Reinstall(ctx, "14b3e7d6-ffb5-4994-8502-57fcd9db3b33", nil)
-
+	instanceRes, err := client.Instance.Reinstall(ctx, "14b3e7d6-ffb5-4994-8502-57fcd9db3b33", nil)
 	if err != nil {
 		t.Errorf("Instance.Reinstall returned %+v", err)
+	}
+
+	expected := &Instance{
+		ID:               "14b3e7d6-ffb5-4994-8502-57fcd9db3b33",
+		Os:               "CentOS SELinux 8 x64",
+		OsID:             362,
+		RAM:              2048,
+		Disk:             60,
+		MainIP:           "123.123.123.123",
+		VCPUCount:        2,
+		Region:           "ewr",
+		DefaultPassword:  "nreqnusibni",
+		DateCreated:      "2013-12-19 14:45:41",
+		Status:           "active",
+		AllowedBandwidth: 2000,
+		NetmaskV4:        "255.255.255.248",
+		GatewayV4:        "123.123.123.1",
+		PowerStatus:      "running",
+		ServerStatus:     "ok",
+		Plan:             "vc2-1c-2gb",
+		V6Network:        "2001:DB8:1000::",
+		V6MainIP:         "fd11:1111:1112:1c02:0200:00ff:fe00:0000",
+		V6NetworkSize:    64,
+		Label:            "my new server",
+		InternalIP:       "10.99.0.10",
+		KVM:              "https://my.vultr.com/subs/novnc/api.php?data=eawxFVZw2mXnhGUV",
+		Tag:              "tagger",
+		AppID:            0,
+		FirewallGroupID:  "1234",
+		Features:         []string{"auto_backups", "ipv6"},
+	}
+
+	if !reflect.DeepEqual(instanceRes, expected) {
+		t.Errorf("Instance.Create returned %+v, expected %+v", server, expected)
 	}
 }
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
This is a slight breaking change as the new version for govultr will require users to add in the new param

This will add in the ability for users to change the hostname during and install which is available on the API call

https://www.vultr.com/api/#operation/reinstall-instance

## Related Issues
#180 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
