### PR TITLE
Fix context error in govultr test

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,30 +25,3 @@ jobs:
         id: test-coverage
         run: |
           go test -cover -v
-
-  comment:
-    runs-on: ubuntu-latest
-    if: github.event_name != 'push'
-    needs: coverage
-    steps:
-      - name: Add Comment
-        uses: actions/github-script@v5
-        if: always()
-        with:
-          script: |
-            const output = `### Unit Tests and Coverage
-            <details><summary>Show Output</summary>
-
-            \`\`\`
-            ${{ needs.coverage.outputs.msg }}
-            \`\`\`
-            </details>
-
-            *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
-
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: output
-            })

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Run unit tests and coverage test
         id: test-coverage
         run: |
-          go test -cover -v > output.txt
+          go test -cover -v
 
   comment:
     runs-on: ubuntu-latest

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,16 +26,6 @@ jobs:
         run: |
           go test -cover -v > output.txt
 
-      - name: Transform output
-        id: results
-        if: always()
-        run: |
-          CONTENT=$(cat output.txt)
-          CONTENT="${CONTENT//'%'/'%25'}"
-          CONTENT="${CONTENT//$'\n'/'%0A'}"
-          CONTENT="${CONTENT//$'\r'/'%0D'}"
-          echo "::set-output name=content::$CONTENT"
-
   comment:
     runs-on: ubuntu-latest
     if: github.event_name != 'push'

--- a/govultr_test.go
+++ b/govultr_test.go
@@ -141,7 +141,7 @@ func TestClient_DoWithContextError(t *testing.T) {
 				panicked = fmt.Sprint(err)
 			}
 		}()
-		client.DoWithContext(context.Background(), req, nil)
+		client.DoWithContext(context.Background(), req, nil) //nolint:all
 	}()
 	if panicked != "" {
 		t.Errorf("unexpected panic: %s", panicked)

--- a/govultr_test.go
+++ b/govultr_test.go
@@ -141,9 +141,7 @@ func TestClient_DoWithContextError(t *testing.T) {
 				panicked = fmt.Sprint(err)
 			}
 		}()
-		if err := client.DoWithContext(context.Background(), req, nil); err != nil {
-			t.Errorf("dowithcontext error: %s", err)
-		}
+		client.DoWithContext(context.Background(), req, nil)
 	}()
 	if panicked != "" {
 		t.Errorf("unexpected panic: %s", panicked)


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
Linting changes prompted a test failure here.  Just remove the error handling like it was before updating to the new library.

Additionally, the codecov bot that was used before stopped working a while back so I think it's pertinent to remove the related actions for now.  The implementation uses deprecated github features and will need to be addressed when re-adding the codecov automation.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
