### PR TITLE
Allow empty password parameter on DBaaS user update

### DIFF
--- a/database.go
+++ b/database.go
@@ -227,7 +227,7 @@ type DatabaseUserCreateReq struct {
 
 // DatabaseUserUpdateReq struct used to update a user within a Managed Database.
 type DatabaseUserUpdateReq struct {
-	Password string `json:"password,omitempty"`
+	Password string `json:"password"`
 }
 
 // DatabaseDB represents a logical database within a Managed Database cluster


### PR DESCRIPTION
## Description
Quick fix to allow empty DBaaS user password parameter to pass through to the Vultr API in order to automatically generate a secure new one. `omitempty` here was hitting a validation error since it removes the parameter from the request body altogether and it needs to at least be set as empty as a sort of user confirmation that they do indeed want to update the db user's password.
