### PR TITLE
Remove unused parameters from database update request

### DIFF
--- a/database.go
+++ b/database.go
@@ -183,8 +183,6 @@ type DatabaseCreateReq struct {
 
 // DatabaseUpdateReq struct used to update a dataase.
 type DatabaseUpdateReq struct {
-	DatabaseEngine         string   `json:"database_engine,omitempty"`
-	DatabaseEngineVersion  string   `json:"database_engine_version,omitempty"`
 	Region                 string   `json:"region,omitempty"`
 	Plan                   string   `json:"plan,omitempty"`
 	Label                  string   `json:"label,omitempty"`


### PR DESCRIPTION
## Description
Database Engine and Database Engine Version are not usable in the update endpoint but were mistakenly included in the request object. This PR removes those.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
