### PR TITLE
Add VPC 2.0

### DIFF
--- a/bare_metal_server.go
+++ b/bare_metal_server.go
@@ -476,7 +476,7 @@ func (b *BareMetalServerServiceHandler) AttachVPC2(ctx context.Context, serverID
 }
 
 // DetachVPC2 from a Bare Metal server.
-func (b *BareMetalServerServiceHandler) DetachVPC2(ctx context.Context, serverID string, vpcID string) error {
+func (b *BareMetalServerServiceHandler) DetachVPC2(ctx context.Context, serverID, vpcID string) error {
 	uri := fmt.Sprintf("%s/%s/vpc2/detach", bmPath, serverID)
 	body := RequestBody{"vpc_id": vpcID}
 

--- a/bare_metal_server_test.go
+++ b/bare_metal_server_test.go
@@ -799,3 +799,56 @@ func TestBareMetalServerServiceHandler_CreateMarketplaceImage(t *testing.T) {
 		t.Errorf("BareMetalServer.Create returned %+v, expected %+v", bm, expected)
 	}
 }
+
+func TestBareMetalServerServiceHandler_ListVPC2Info(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/bare-metals/14b3e7d6-ffb5-4994-8502-57fcd9db3b33/vpc2", func(writer http.ResponseWriter, request *http.Request) {
+		response := `{"vpcs": [{"id": "v1-net539626f0798d7","mac_address": "5a:02:00:00:24:e9","ip_address": "10.99.0.3"}]}`
+		fmt.Fprint(writer, response)
+	})
+
+	vpc, _, err := client.BareMetalServer.ListVPC2Info(ctx, "14b3e7d6-ffb5-4994-8502-57fcd9db3b33")
+	if err != nil {
+		t.Errorf("BareMetalServer.ListVPC2Info returned %+v, ", err)
+	}
+
+	expected := []VPC2Info{
+		{
+			ID:         "v1-net539626f0798d7",
+			MacAddress: "5a:02:00:00:24:e9",
+			IPAddress:  "10.99.0.3",
+		},
+	}
+
+	if !reflect.DeepEqual(vpc, expected) {
+		t.Errorf("BareMetalServer.ListVPC2Info returned %+v, expected %+v", vpc, expected)
+	}
+}
+
+func TestBareMetalServerServiceHandler_AttachVPC2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/bare-metals/14b3e7d6-ffb5-4994-8502-57fcd9db3b33/vpc2/attach", func(writer http.ResponseWriter, request *http.Request) {
+		fmt.Fprint(writer)
+	})
+
+	if err := client.BareMetalServer.AttachVPC2(ctx, "14b3e7d6-ffb5-4994-8502-57fcd9db3b33", &AttachVPC2Req{VPCID: "14b3e7d6-ffb5-4994-8502-57fcd9db3b33"}); err != nil {
+		t.Errorf("BareMetalServer.AttachVPC2 returned %+v", err)
+	}
+}
+
+func TestBareMetalServerServiceHandler_DetachVPC2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/bare-metals/14b3e7d6-ffb5-4994-8502-57fcd9db3b33/vpc2/detach", func(writer http.ResponseWriter, request *http.Request) {
+		fmt.Fprint(writer)
+	})
+
+	if err := client.BareMetalServer.DetachVPC2(ctx, "14b3e7d6-ffb5-4994-8502-57fcd9db3b33", "14b3e7d6-ffb5-4994-8502-57fcd9db3b33"); err != nil {
+		t.Errorf("BareMetalServer.DetachVPC2 returned %+v", err)
+	}
+}

--- a/govultr.go
+++ b/govultr.go
@@ -66,6 +66,7 @@ type Client struct {
 	StartupScript StartupScriptService
 	User          UserService
 	VPC           VPCService
+	VPC2          VPC2Service
 
 	// Optional function called after every successful request made to the Vultr API
 	onRequestCompleted RequestCompletionCallback
@@ -135,6 +136,7 @@ func NewClient(httpClient *http.Client) *Client {
 	client.StartupScript = &StartupScriptServiceHandler{client}
 	client.User = &UserServiceHandler{client}
 	client.VPC = &VPCServiceHandler{client}
+	client.VPC2 = &VPC2ServiceHandler{client}
 
 	return client
 }

--- a/instance_test.go
+++ b/instance_test.go
@@ -241,6 +241,49 @@ func TestServerServiceHandler_ListVPCInfo(t *testing.T) {
 	}
 }
 
+func TestServerServiceHandler_ListVPC2Info(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/instances/14b3e7d6-ffb5-4994-8502-57fcd9db3b33/vpc2", func(writer http.ResponseWriter, request *http.Request) {
+		response := `{"vpcs": [{"id": "v1-net539626f0798d7","mac_address": "5a:02:00:00:24:e9","ip_address": "10.99.0.3"}],"meta":{"total":1,"links":{"next":"thisismycusror","prev":""}}}`
+		fmt.Fprint(writer, response)
+	})
+
+	options := &ListOptions{
+		PerPage: 1,
+		Cursor:  "",
+	}
+	vpc, meta, _, err := client.Instance.ListVPC2Info(ctx, "14b3e7d6-ffb5-4994-8502-57fcd9db3b33", options)
+	if err != nil {
+		t.Errorf("Instance.ListVPC2Info returned %+v, ", err)
+	}
+
+	expected := []VPC2Info{
+		{
+			ID:         "v1-net539626f0798d7",
+			MacAddress: "5a:02:00:00:24:e9",
+			IPAddress:  "10.99.0.3",
+		},
+	}
+
+	if !reflect.DeepEqual(vpc, expected) {
+		t.Errorf("Instance.ListVPC2Info returned %+v, expected %+v", vpc, expected)
+	}
+
+	expectedMeta := &Meta{
+		Total: 1,
+		Links: &Links{
+			Next: "thisismycusror",
+			Prev: "",
+		},
+	}
+
+	if !reflect.DeepEqual(meta, expectedMeta) {
+		t.Errorf("Instance.ListVPC2Info meta returned %+v, expected %+v", meta, expectedMeta)
+	}
+}
+
 func TestServerServiceHandler_GetUserData(t *testing.T) {
 	setup()
 	defer teardown()
@@ -986,6 +1029,32 @@ func TestServerServiceHandler_DetachVPC(t *testing.T) {
 
 	if err := client.Instance.DetachVPC(ctx, "14b3e7d6-ffb5-4994-8502-57fcd9db3b33", "14b3e7d6-ffb5-4994-8502-57fcd9db3b33"); err != nil {
 		t.Errorf("Instance.DetachVPC returned %+v", err)
+	}
+}
+
+func TestServerServiceHandler_AttachVPC2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/instances/14b3e7d6-ffb5-4994-8502-57fcd9db3b33/vpc2/attach", func(writer http.ResponseWriter, request *http.Request) {
+		fmt.Fprint(writer)
+	})
+
+	if err := client.Instance.AttachVPC2(ctx, "14b3e7d6-ffb5-4994-8502-57fcd9db3b33", &AttachVPC2Req{VPCID: "14b3e7d6-ffb5-4994-8502-57fcd9db3b33"}); err != nil {
+		t.Errorf("Instance.AttachVPC2 returned %+v", err)
+	}
+}
+
+func TestServerServiceHandler_DetachVPC2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/instances/14b3e7d6-ffb5-4994-8502-57fcd9db3b33/vpc2/detach", func(writer http.ResponseWriter, request *http.Request) {
+		fmt.Fprint(writer)
+	})
+
+	if err := client.Instance.DetachVPC2(ctx, "14b3e7d6-ffb5-4994-8502-57fcd9db3b33", "14b3e7d6-ffb5-4994-8502-57fcd9db3b33"); err != nil {
+		t.Errorf("Instance.DetachVPC2 returned %+v", err)
 	}
 }
 

--- a/network.go
+++ b/network.go
@@ -13,7 +13,7 @@ const netPath = "/v2/private-networks"
 // NetworkService is the interface to interact with the network endpoints on the Vultr API
 // Link : https://www.vultr.com/api/#tag/private-Networks
 // Deprecated: NetworkService should no longer be used. Instead, use VPCService.
-type NetworkService interface {
+type NetworkService interface { //nolint:dupl
 	// Deprecated: NetworkService Create should no longer be used. Instead, use VPCService Create.
 	Create(ctx context.Context, createReq *NetworkReq) (*Network, *http.Response, error)
 	// Deprecated: NetworkService Get should no longer be used. Instead, use VPCService Get.

--- a/vpc.go
+++ b/vpc.go
@@ -12,7 +12,7 @@ const vpcPath = "/v2/vpcs"
 
 // VPCService is the interface to interact with the VPC endpoints on the Vultr API
 // Link : https://www.vultr.com/api/#tag/vpcs
-type VPCService interface {
+type VPCService interface { //nolint:dupl
 	Create(ctx context.Context, createReq *VPCReq) (*VPC, *http.Response, error)
 	Get(ctx context.Context, vpcID string) (*VPC, *http.Response, error)
 	Update(ctx context.Context, vpcID string, description string) error

--- a/vpc2.go
+++ b/vpc2.go
@@ -1,0 +1,134 @@
+package govultr //nolint:dupl
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/google/go-querystring/query"
+)
+
+const vpcPath = "/v2/vpcs"
+
+// VPCService is the interface to interact with the VPC endpoints on the Vultr API
+// Link : https://www.vultr.com/api/#tag/vpcs
+type VPCService interface {
+	Create(ctx context.Context, createReq *VPCReq) (*VPC, *http.Response, error)
+	Get(ctx context.Context, vpcID string) (*VPC, *http.Response, error)
+	Update(ctx context.Context, vpcID string, description string) error
+	Delete(ctx context.Context, vpcID string) error
+	List(ctx context.Context, options *ListOptions) ([]VPC, *Meta, *http.Response, error)
+}
+
+// VPCServiceHandler handles interaction with the VPC methods for the Vultr API
+type VPCServiceHandler struct {
+	client *Client
+}
+
+// VPC represents a Vultr VPC
+type VPC struct {
+	ID           string `json:"id"`
+	Region       string `json:"region"`
+	Description  string `json:"description"`
+	V4Subnet     string `json:"v4_subnet"`
+	V4SubnetMask int    `json:"v4_subnet_mask"`
+	DateCreated  string `json:"date_created"`
+}
+
+// VPCReq represents parameters to create or update a VPC resource
+type VPCReq struct {
+	Region       string `json:"region"`
+	Description  string `json:"description"`
+	V4Subnet     string `json:"v4_subnet"`
+	V4SubnetMask int    `json:"v4_subnet_mask"`
+}
+
+type vpcsBase struct {
+	VPCs []VPC `json:"vpcs"`
+	Meta *Meta `json:"meta"`
+}
+
+type vpcBase struct {
+	VPC *VPC `json:"vpc"`
+}
+
+// Create creates a new VPC. A VPC can only be used at the location for which it was created.
+func (n *VPCServiceHandler) Create(ctx context.Context, createReq *VPCReq) (*VPC, *http.Response, error) {
+	req, err := n.client.NewRequest(ctx, http.MethodPost, vpcPath, createReq)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	vpc := new(vpcBase)
+	resp, err := n.client.DoWithContext(ctx, req, vpc)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return vpc.VPC, resp, nil
+}
+
+// Get gets the VPC of the requested ID
+func (n *VPCServiceHandler) Get(ctx context.Context, vpcID string) (*VPC, *http.Response, error) {
+	uri := fmt.Sprintf("%s/%s", vpcPath, vpcID)
+	req, err := n.client.NewRequest(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	vpc := new(vpcBase)
+	resp, err := n.client.DoWithContext(ctx, req, vpc)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return vpc.VPC, resp, nil
+}
+
+// Update updates a VPC
+func (n *VPCServiceHandler) Update(ctx context.Context, vpcID, description string) error {
+	uri := fmt.Sprintf("%s/%s", vpcPath, vpcID)
+
+	vpcReq := RequestBody{"description": description}
+	req, err := n.client.NewRequest(ctx, http.MethodPut, uri, vpcReq)
+	if err != nil {
+		return err
+	}
+
+	_, err = n.client.DoWithContext(ctx, req, nil)
+	return err
+}
+
+// Delete deletes a VPC. Before deleting, a VPC must be disabled from all instances
+func (n *VPCServiceHandler) Delete(ctx context.Context, vpcID string) error {
+	uri := fmt.Sprintf("%s/%s", vpcPath, vpcID)
+	req, err := n.client.NewRequest(ctx, http.MethodDelete, uri, nil)
+	if err != nil {
+		return err
+	}
+	_, err = n.client.DoWithContext(ctx, req, nil)
+	return err
+}
+
+// List lists all VPCs on the current account
+func (n *VPCServiceHandler) List(ctx context.Context, options *ListOptions) ([]VPC, *Meta, *http.Response, error) { //nolint:dupl
+	req, err := n.client.NewRequest(ctx, http.MethodGet, vpcPath, nil)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	newValues, err := query.Values(options)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	req.URL.RawQuery = newValues.Encode()
+
+	vpcs := new(vpcsBase)
+	resp, err := n.client.DoWithContext(ctx, req, vpcs)
+	if err != nil {
+		return nil, nil, resp, err
+	}
+
+	return vpcs.VPCs, vpcs.Meta, resp, nil
+}

--- a/vpc2.go
+++ b/vpc2.go
@@ -111,7 +111,7 @@ func (n *VPC2ServiceHandler) Delete(ctx context.Context, vpcID string) error {
 	return err
 }
 
-// List lists all VPC 2.0 on the current account
+// List lists all VPCs 2.0 on the current account
 func (n *VPC2ServiceHandler) List(ctx context.Context, options *ListOptions) ([]VPC2, *Meta, *http.Response, error) { //nolint:dupl
 	req, err := n.client.NewRequest(ctx, http.MethodGet, vpc2Path, nil)
 	if err != nil {

--- a/vpc2.go
+++ b/vpc2.go
@@ -8,58 +8,59 @@ import (
 	"github.com/google/go-querystring/query"
 )
 
-const vpcPath = "/v2/vpcs"
+const vpc2Path = "/v2/vpc2"
 
-// VPCService is the interface to interact with the VPC endpoints on the Vultr API
-// Link : https://www.vultr.com/api/#tag/vpcs
-type VPCService interface {
-	Create(ctx context.Context, createReq *VPCReq) (*VPC, *http.Response, error)
-	Get(ctx context.Context, vpcID string) (*VPC, *http.Response, error)
+// VPC2Service is the interface to interact with the VPC 2.0 endpoints on the Vultr API
+// Link : https://www.vultr.com/api/#tag/vpc2
+type VPC2Service interface {
+	Create(ctx context.Context, createReq *VPC2Req) (*VPC2, *http.Response, error)
+	Get(ctx context.Context, vpcID string) (*VPC2, *http.Response, error)
 	Update(ctx context.Context, vpcID string, description string) error
 	Delete(ctx context.Context, vpcID string) error
-	List(ctx context.Context, options *ListOptions) ([]VPC, *Meta, *http.Response, error)
+	List(ctx context.Context, options *ListOptions) ([]VPC2, *Meta, *http.Response, error)
 }
 
-// VPCServiceHandler handles interaction with the VPC methods for the Vultr API
-type VPCServiceHandler struct {
+// VPC2ServiceHandler handles interaction with the VPC 2.0 methods for the Vultr API
+type VPC2ServiceHandler struct {
 	client *Client
 }
 
-// VPC represents a Vultr VPC
-type VPC struct {
+// VPC2 represents a Vultr VPC 2.0
+type VPC2 struct {
 	ID           string `json:"id"`
 	Region       string `json:"region"`
 	Description  string `json:"description"`
-	V4Subnet     string `json:"v4_subnet"`
-	V4SubnetMask int    `json:"v4_subnet_mask"`
+	IPBlock      string `json:"ip_block"`
+	PrefixLength int    `json:"prefix_length"`
 	DateCreated  string `json:"date_created"`
 }
 
-// VPCReq represents parameters to create or update a VPC resource
-type VPCReq struct {
+// VPC2Req represents parameters to create or update a VPC 2.0 resource
+type VPC2Req struct {
 	Region       string `json:"region"`
 	Description  string `json:"description"`
-	V4Subnet     string `json:"v4_subnet"`
-	V4SubnetMask int    `json:"v4_subnet_mask"`
+	IPType       string `json:"ip_type"`
+	IPBlock      string `json:"ip_block"`
+	PrefixLength int    `json:"prefix_length"`
 }
 
-type vpcsBase struct {
-	VPCs []VPC `json:"vpcs"`
-	Meta *Meta `json:"meta"`
+type vpcs2Base struct {
+	VPCs []VPC2 `json:"vpcs"`
+	Meta *Meta  `json:"meta"`
 }
 
-type vpcBase struct {
-	VPC *VPC `json:"vpc"`
+type vpc2Base struct {
+	VPC *VPC2 `json:"vpc"`
 }
 
-// Create creates a new VPC. A VPC can only be used at the location for which it was created.
-func (n *VPCServiceHandler) Create(ctx context.Context, createReq *VPCReq) (*VPC, *http.Response, error) {
-	req, err := n.client.NewRequest(ctx, http.MethodPost, vpcPath, createReq)
+// Create creates a new VPC 2.0. A VPC 2.0 can only be used at the location for which it was created.
+func (n *VPC2ServiceHandler) Create(ctx context.Context, createReq *VPC2Req) (*VPC2, *http.Response, error) {
+	req, err := n.client.NewRequest(ctx, http.MethodPost, vpc2Path, createReq)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	vpc := new(vpcBase)
+	vpc := new(vpc2Base)
 	resp, err := n.client.DoWithContext(ctx, req, vpc)
 	if err != nil {
 		return nil, resp, err
@@ -68,15 +69,15 @@ func (n *VPCServiceHandler) Create(ctx context.Context, createReq *VPCReq) (*VPC
 	return vpc.VPC, resp, nil
 }
 
-// Get gets the VPC of the requested ID
-func (n *VPCServiceHandler) Get(ctx context.Context, vpcID string) (*VPC, *http.Response, error) {
-	uri := fmt.Sprintf("%s/%s", vpcPath, vpcID)
+// Get gets the VPC 2.0 of the requested ID
+func (n *VPC2ServiceHandler) Get(ctx context.Context, vpcID string) (*VPC2, *http.Response, error) {
+	uri := fmt.Sprintf("%s/%s", vpc2Path, vpcID)
 	req, err := n.client.NewRequest(ctx, http.MethodGet, uri, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	vpc := new(vpcBase)
+	vpc := new(vpc2Base)
 	resp, err := n.client.DoWithContext(ctx, req, vpc)
 	if err != nil {
 		return nil, resp, err
@@ -85,9 +86,9 @@ func (n *VPCServiceHandler) Get(ctx context.Context, vpcID string) (*VPC, *http.
 	return vpc.VPC, resp, nil
 }
 
-// Update updates a VPC
-func (n *VPCServiceHandler) Update(ctx context.Context, vpcID, description string) error {
-	uri := fmt.Sprintf("%s/%s", vpcPath, vpcID)
+// Update updates a VPC 2.0
+func (n *VPC2ServiceHandler) Update(ctx context.Context, vpcID, description string) error {
+	uri := fmt.Sprintf("%s/%s", vpc2Path, vpcID)
 
 	vpcReq := RequestBody{"description": description}
 	req, err := n.client.NewRequest(ctx, http.MethodPut, uri, vpcReq)
@@ -99,9 +100,9 @@ func (n *VPCServiceHandler) Update(ctx context.Context, vpcID, description strin
 	return err
 }
 
-// Delete deletes a VPC. Before deleting, a VPC must be disabled from all instances
-func (n *VPCServiceHandler) Delete(ctx context.Context, vpcID string) error {
-	uri := fmt.Sprintf("%s/%s", vpcPath, vpcID)
+// Delete deletes a VPC 2.0. Before deleting, a VPC 2.0 must be disabled from all instances
+func (n *VPC2ServiceHandler) Delete(ctx context.Context, vpcID string) error {
+	uri := fmt.Sprintf("%s/%s", vpc2Path, vpcID)
 	req, err := n.client.NewRequest(ctx, http.MethodDelete, uri, nil)
 	if err != nil {
 		return err
@@ -110,9 +111,9 @@ func (n *VPCServiceHandler) Delete(ctx context.Context, vpcID string) error {
 	return err
 }
 
-// List lists all VPCs on the current account
-func (n *VPCServiceHandler) List(ctx context.Context, options *ListOptions) ([]VPC, *Meta, *http.Response, error) { //nolint:dupl
-	req, err := n.client.NewRequest(ctx, http.MethodGet, vpcPath, nil)
+// List lists all VPC 2.0 on the current account
+func (n *VPC2ServiceHandler) List(ctx context.Context, options *ListOptions) ([]VPC2, *Meta, *http.Response, error) { //nolint:dupl
+	req, err := n.client.NewRequest(ctx, http.MethodGet, vpc2Path, nil)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -124,7 +125,7 @@ func (n *VPCServiceHandler) List(ctx context.Context, options *ListOptions) ([]V
 
 	req.URL.RawQuery = newValues.Encode()
 
-	vpcs := new(vpcsBase)
+	vpcs := new(vpcs2Base)
 	resp, err := n.client.DoWithContext(ctx, req, vpcs)
 	if err != nil {
 		return nil, nil, resp, err

--- a/vpc2.go
+++ b/vpc2.go
@@ -1,4 +1,4 @@
-package govultr //nolint:dupl
+package govultr
 
 import (
 	"context"
@@ -12,7 +12,7 @@ const vpc2Path = "/v2/vpc2"
 
 // VPC2Service is the interface to interact with the VPC 2.0 endpoints on the Vultr API
 // Link : https://www.vultr.com/api/#tag/vpc2
-type VPC2Service interface {
+type VPC2Service interface { //nolint:dupl
 	Create(ctx context.Context, createReq *VPC2Req) (*VPC2, *http.Response, error)
 	Get(ctx context.Context, vpcID string) (*VPC2, *http.Response, error)
 	Update(ctx context.Context, vpcID string, description string) error

--- a/vpc2_test.go
+++ b/vpc2_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 )
 
-func TestVPCServiceHandler_Create(t *testing.T) {
+func TestVPC2ServiceHandler_Create(t *testing.T) {
 	setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/vpcs", func(writer http.ResponseWriter, request *http.Request) {
+	mux.HandleFunc("/v2/vpc2", func(writer http.ResponseWriter, request *http.Request) {
 		response := `
 		{
 			"vpc": {
@@ -19,8 +19,8 @@ func TestVPCServiceHandler_Create(t *testing.T) {
 				"date_created": "2017-08-25 12:23:45",
 				"region": "ewr",
 				"description": "test1",
-				"v4_subnet": "10.99.0.0",
-				"v4_subnet_mask": 24
+				"ip_block": "10.99.0.0",
+				"prefix_length": 24
 			}
 		}
 		`
@@ -28,51 +28,51 @@ func TestVPCServiceHandler_Create(t *testing.T) {
 		fmt.Fprint(writer, response)
 	})
 
-	options := &VPCReq{
+	options := &VPC2Req{
 		Region:      "ewr",
 		Description: "test1",
 	}
 
-	net, _, err := client.VPC.Create(ctx, options)
+	net, _, err := client.VPC2.Create(ctx, options)
 
 	if err != nil {
-		t.Errorf("VPC.Create returned %+v, expected %+v", err, nil)
+		t.Errorf("VPC2.Create returned %+v, expected %+v", err, nil)
 	}
 
-	expected := &VPC{
+	expected := &VPC2{
 		ID:           "net539626f0798d7",
 		Region:       "ewr",
 		Description:  "test1",
-		V4Subnet:     "10.99.0.0",
-		V4SubnetMask: 24,
+		IPBlock:      "10.99.0.0",
+		PrefixLength: 24,
 		DateCreated:  "2017-08-25 12:23:45",
 	}
 
 	if !reflect.DeepEqual(net, expected) {
-		t.Errorf("VPC.Create returned %+v, expected %+v", net, expected)
+		t.Errorf("VPC2.Create returned %+v, expected %+v", net, expected)
 	}
 }
 
-func TestVPCServiceHandler_Delete(t *testing.T) {
+func TestVPC2ServiceHandler_Delete(t *testing.T) {
 	setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/vpcs/net539626f0798d7", func(writer http.ResponseWriter, request *http.Request) {
+	mux.HandleFunc("/v2/vpc2/net539626f0798d7", func(writer http.ResponseWriter, request *http.Request) {
 		fmt.Fprint(writer)
 	})
 
-	err := client.VPC.Delete(ctx, "net539626f0798d7")
+	err := client.VPC2.Delete(ctx, "net539626f0798d7")
 
 	if err != nil {
-		t.Errorf("VPC.Delete returned %+v, expected %+v", err, nil)
+		t.Errorf("VPC2.Delete returned %+v, expected %+v", err, nil)
 	}
 }
 
-func TestVPCServiceHandler_List(t *testing.T) {
+func TestVPC2ServiceHandler_List(t *testing.T) {
 	setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/vpcs", func(writer http.ResponseWriter, request *http.Request) {
+	mux.HandleFunc("/v2/vpc2", func(writer http.ResponseWriter, request *http.Request) {
 		response := `
 		{
 			"vpcs": [{
@@ -80,75 +80,75 @@ func TestVPCServiceHandler_List(t *testing.T) {
 				"date_created": "2017-08-25 12:23:45",
 				"region": "ewr",
 				"description": "test1",
-				"v4_subnet": "10.99.0.0",
-				"v4_subnet_mask": 24
+				"ip_block": "10.99.0.0",
+				"prefix_length": 24
 			}]
 		}
 		`
 		fmt.Fprint(writer, response)
 	})
 
-	vpcs, _, _, err := client.VPC.List(ctx, nil)
+	vpcs, _, _, err := client.VPC2.List(ctx, nil)
 
 	if err != nil {
-		t.Errorf("VPC.List returned error: %v", err)
+		t.Errorf("VPC2.List returned error: %v", err)
 	}
 
-	expected := []VPC{
+	expected := []VPC2{
 		{
 			ID:           "net539626f0798d7",
 			Region:       "ewr",
 			Description:  "test1",
-			V4Subnet:     "10.99.0.0",
-			V4SubnetMask: 24,
+			IPBlock:      "10.99.0.0",
+			PrefixLength: 24,
 			DateCreated:  "2017-08-25 12:23:45",
 		},
 	}
 
 	if !reflect.DeepEqual(vpcs, expected) {
-		t.Errorf("VPC.List returned %+v, expected %+v", vpcs, expected)
+		t.Errorf("VPC2.List returned %+v, expected %+v", vpcs, expected)
 	}
 }
 
-func TestVPCServiceHandler_Update(t *testing.T) {
+func TestVPC2ServiceHandler_Update(t *testing.T) {
 	setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/vpcs/net539626f0798d7", func(writer http.ResponseWriter, request *http.Request) {
+	mux.HandleFunc("/v2/vpc2/net539626f0798d7", func(writer http.ResponseWriter, request *http.Request) {
 		fmt.Fprint(writer)
 	})
 
-	err := client.VPC.Update(ctx, "net539626f0798d7", "update")
+	err := client.VPC2.Update(ctx, "net539626f0798d7", "update")
 
 	if err != nil {
-		t.Errorf("VPC.Update returned %+v, expected %+v", err, nil)
+		t.Errorf("VPC2.Update returned %+v, expected %+v", err, nil)
 	}
 }
 
-func TestVPCServiceHandler_Get(t *testing.T) {
+func TestVPC2ServiceHandler_Get(t *testing.T) {
 	setup()
 	defer teardown()
 
-	mux.HandleFunc("/v2/vpcs/net539626f0798d7", func(writer http.ResponseWriter, request *http.Request) {
-		req := `{"vpc": {"id": "cb676a46-66fd-4dfb-b839-443f2e6c0b60","date_created": "2020-10-10T01:56:20+00:00","region": "ewr","description": "sample desc","v4_subnet": "10.99.0.0","v4_subnet_mask": 24}}`
+	mux.HandleFunc("/v2/vpc2/net539626f0798d7", func(writer http.ResponseWriter, request *http.Request) {
+		req := `{"vpc": {"id": "cb676a46-66fd-4dfb-b839-443f2e6c0b60","date_created": "2020-10-10T01:56:20+00:00","region": "ewr","description": "sample desc","ip_block": "10.99.0.0","prefix_length": 24}}`
 		fmt.Fprint(writer, req)
 	})
 
-	vpc, _, err := client.VPC.Get(ctx, "net539626f0798d7")
+	vpc, _, err := client.VPC2.Get(ctx, "net539626f0798d7")
 	if err != nil {
-		t.Errorf("VPC.Get returned %+v, expected %+v", err, nil)
+		t.Errorf("VPC2.Get returned %+v, expected %+v", err, nil)
 	}
 
-	expected := &VPC{
+	expected := &VPC2{
 		ID:           "cb676a46-66fd-4dfb-b839-443f2e6c0b60",
 		Region:       "ewr",
 		Description:  "sample desc",
-		V4Subnet:     "10.99.0.0",
-		V4SubnetMask: 24,
+		IPBlock:      "10.99.0.0",
+		PrefixLength: 24,
 		DateCreated:  "2020-10-10T01:56:20+00:00",
 	}
 
 	if !reflect.DeepEqual(vpc, expected) {
-		t.Errorf("VPC.Get returned %+v, expected %+v", vpc, expected)
+		t.Errorf("VPC2.Get returned %+v, expected %+v", vpc, expected)
 	}
 }

--- a/vpc2_test.go
+++ b/vpc2_test.go
@@ -1,0 +1,154 @@
+package govultr
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestVPCServiceHandler_Create(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/vpcs", func(writer http.ResponseWriter, request *http.Request) {
+		response := `
+		{
+			"vpc": {
+				"id": "net539626f0798d7",
+				"date_created": "2017-08-25 12:23:45",
+				"region": "ewr",
+				"description": "test1",
+				"v4_subnet": "10.99.0.0",
+				"v4_subnet_mask": 24
+			}
+		}
+		`
+
+		fmt.Fprint(writer, response)
+	})
+
+	options := &VPCReq{
+		Region:      "ewr",
+		Description: "test1",
+	}
+
+	net, _, err := client.VPC.Create(ctx, options)
+
+	if err != nil {
+		t.Errorf("VPC.Create returned %+v, expected %+v", err, nil)
+	}
+
+	expected := &VPC{
+		ID:           "net539626f0798d7",
+		Region:       "ewr",
+		Description:  "test1",
+		V4Subnet:     "10.99.0.0",
+		V4SubnetMask: 24,
+		DateCreated:  "2017-08-25 12:23:45",
+	}
+
+	if !reflect.DeepEqual(net, expected) {
+		t.Errorf("VPC.Create returned %+v, expected %+v", net, expected)
+	}
+}
+
+func TestVPCServiceHandler_Delete(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/vpcs/net539626f0798d7", func(writer http.ResponseWriter, request *http.Request) {
+		fmt.Fprint(writer)
+	})
+
+	err := client.VPC.Delete(ctx, "net539626f0798d7")
+
+	if err != nil {
+		t.Errorf("VPC.Delete returned %+v, expected %+v", err, nil)
+	}
+}
+
+func TestVPCServiceHandler_List(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/vpcs", func(writer http.ResponseWriter, request *http.Request) {
+		response := `
+		{
+			"vpcs": [{
+				"id": "net539626f0798d7",
+				"date_created": "2017-08-25 12:23:45",
+				"region": "ewr",
+				"description": "test1",
+				"v4_subnet": "10.99.0.0",
+				"v4_subnet_mask": 24
+			}]
+		}
+		`
+		fmt.Fprint(writer, response)
+	})
+
+	vpcs, _, _, err := client.VPC.List(ctx, nil)
+
+	if err != nil {
+		t.Errorf("VPC.List returned error: %v", err)
+	}
+
+	expected := []VPC{
+		{
+			ID:           "net539626f0798d7",
+			Region:       "ewr",
+			Description:  "test1",
+			V4Subnet:     "10.99.0.0",
+			V4SubnetMask: 24,
+			DateCreated:  "2017-08-25 12:23:45",
+		},
+	}
+
+	if !reflect.DeepEqual(vpcs, expected) {
+		t.Errorf("VPC.List returned %+v, expected %+v", vpcs, expected)
+	}
+}
+
+func TestVPCServiceHandler_Update(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/vpcs/net539626f0798d7", func(writer http.ResponseWriter, request *http.Request) {
+		fmt.Fprint(writer)
+	})
+
+	err := client.VPC.Update(ctx, "net539626f0798d7", "update")
+
+	if err != nil {
+		t.Errorf("VPC.Update returned %+v, expected %+v", err, nil)
+	}
+}
+
+func TestVPCServiceHandler_Get(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/vpcs/net539626f0798d7", func(writer http.ResponseWriter, request *http.Request) {
+		req := `{"vpc": {"id": "cb676a46-66fd-4dfb-b839-443f2e6c0b60","date_created": "2020-10-10T01:56:20+00:00","region": "ewr","description": "sample desc","v4_subnet": "10.99.0.0","v4_subnet_mask": 24}}`
+		fmt.Fprint(writer, req)
+	})
+
+	vpc, _, err := client.VPC.Get(ctx, "net539626f0798d7")
+	if err != nil {
+		t.Errorf("VPC.Get returned %+v, expected %+v", err, nil)
+	}
+
+	expected := &VPC{
+		ID:           "cb676a46-66fd-4dfb-b839-443f2e6c0b60",
+		Region:       "ewr",
+		Description:  "sample desc",
+		V4Subnet:     "10.99.0.0",
+		V4SubnetMask: 24,
+		DateCreated:  "2020-10-10T01:56:20+00:00",
+	}
+
+	if !reflect.DeepEqual(vpc, expected) {
+		t.Errorf("VPC.Get returned %+v, expected %+v", vpc, expected)
+	}
+}


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
Add VPC 2.0.
VKE now automatically creates VPC 2.0. So VPC 2.0 is important to manage with Terraform.

I implemented it with reference to Vultr's API document and OpenAPI specification.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
