### PR TITLE
Convert DatabaseUpdate VPCID to pointer for empty values

### DIFF
--- a/database.go
+++ b/database.go
@@ -190,7 +190,7 @@ type DatabaseUpdateReq struct {
 	Plan                   string   `json:"plan,omitempty"`
 	Label                  string   `json:"label,omitempty"`
 	Tag                    string   `json:"tag,omitempty"`
-	VPCID                  string   `json:"vpc_id,omitempty"`
+	VPCID                  *string  `json:"vpc_id,omitempty"`
 	MaintenanceDOW         string   `json:"maintenance_dow,omitempty"`
 	MaintenanceTime        string   `json:"maintenance_time,omitempty"`
 	ClusterTimeZone        string   `json:"cluster_time_zone,omitempty"`


### PR DESCRIPTION
## Description
Managed Database updates were failing to send an empty string to the Vultr API to detach VPCs, so this PR converts it into a pointer so it can safely be omitted, empty string, or VPCID string as the situation dictates.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
