### PR TITLE
Add HA control planes support for VKE

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -43,17 +43,18 @@ type KubernetesHandler struct {
 
 // Cluster represents a full VKE cluster
 type Cluster struct {
-	ID            string     `json:"id"`
-	Label         string     `json:"label"`
-	DateCreated   string     `json:"date_created"`
-	ClusterSubnet string     `json:"cluster_subnet"`
-	ServiceSubnet string     `json:"service_subnet"`
-	IP            string     `json:"ip"`
-	Endpoint      string     `json:"endpoint"`
-	Version       string     `json:"version"`
-	Region        string     `json:"region"`
-	Status        string     `json:"status"`
-	NodePools     []NodePool `json:"node_pools"`
+	ID              string     `json:"id"`
+	Label           string     `json:"label"`
+	DateCreated     string     `json:"date_created"`
+	ClusterSubnet   string     `json:"cluster_subnet"`
+	ServiceSubnet   string     `json:"service_subnet"`
+	IP              string     `json:"ip"`
+	Endpoint        string     `json:"endpoint"`
+	Version         string     `json:"version"`
+	Region          string     `json:"region"`
+	Status          string     `json:"status"`
+	HAControlPlanes bool       `json:"ha_controlplanes"`
+	NodePools       []NodePool `json:"node_pools"`
 }
 
 // NodePool represents a pool of nodes that are grouped by their label and plan type
@@ -87,10 +88,11 @@ type KubeConfig struct {
 
 // ClusterReq struct used to create a cluster
 type ClusterReq struct {
-	Label     string        `json:"label"`
-	Region    string        `json:"region"`
-	Version   string        `json:"version"`
-	NodePools []NodePoolReq `json:"node_pools"`
+	Label           string        `json:"label"`
+	Region          string        `json:"region"`
+	Version         string        `json:"version"`
+	HAControlPlanes bool          `json:"ha_controlplanes,omitempty"`
+	NodePools       []NodePoolReq `json:"node_pools"`
 }
 
 // ClusterReqUpdate struct used to update update a cluster


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
Adds support for the `ha_controlplanes` field that was added to the API.  Setting this `true` will deploy the cluster with highly available control planes.

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
