### PR TITLE
Add managed firewall support for VKE

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -54,6 +54,7 @@ type Cluster struct {
 	Region          string     `json:"region"`
 	Status          string     `json:"status"`
 	HAControlPlanes bool       `json:"ha_controlplanes"`
+	FirewallGroupID string     `json:"firewall_group_id"`
 	NodePools       []NodePool `json:"node_pools"`
 }
 
@@ -92,6 +93,7 @@ type ClusterReq struct {
 	Region          string        `json:"region"`
 	Version         string        `json:"version"`
 	HAControlPlanes bool          `json:"ha_controlplanes,omitempty"`
+	EnableFirewall  bool          `json:"enable_firewall,omitempty"`
 	NodePools       []NodePoolReq `json:"node_pools"`
 }
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description

Adds support for the `firewall_group_id` field that is now returned as part of VKE cluster responses.

Additionally adds support for `enable_firewall` which can be provided when creating a new VKE cluster. When enabled, a Firewall Group will be deployed and managed by the cluster, ensuring worker nodes are automatically linked to the firewall.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
