### PR TITLE
Add support for container registry operations

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -130,6 +130,8 @@ issues:
         - dupl
         - gosec
         - lll
+        - goconst
+        - dogsled
 
 run:
   timeout: 5m

--- a/container_registry.go
+++ b/container_registry.go
@@ -1,0 +1,304 @@
+package govultr
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/google/go-querystring/query"
+)
+
+const vcrPath = "/v2/registry"
+const vcrListPath = "/v2/registries"
+
+// ContainerRegistryService is the interface to interact with the container registry endpoints on the Vultr API.
+// Link : https://www.vultr.com/api/#tag/Container-Registry
+type ContainerRegistryService interface {
+	Create(ctx context.Context, createReq *ContainerRegistryReq) (*ContainerRegistry, *http.Response, error)
+	Get(ctx context.Context, vcrID string) (*ContainerRegistry, *http.Response, error)
+	Update(ctx context.Context, vcrID string, updateReq *ContainerRegistryReqUpdate) (*ContainerRegistry, *http.Response, error)
+	Delete(ctx context.Context, vcrID string) error
+	List(ctx context.Context, options *ListOptions) ([]ContainerRegistry, *Meta, *http.Response, error)
+	ListRepositories(ctx context.Context, vcrID string, options *ListOptions) ([]ContainerRegistryRepo, *Meta, *http.Response, error)
+	GetRepository(ctx context.Context, vcrID, imageName string) (*ContainerRegistryRepo, *http.Response, error)
+	UpdateRepository(ctx context.Context, vcrID, imageName string, updateReq *ContainerRegistryRepoReqUpdate) (*ContainerRegistryRepo, *http.Response, error)
+	DeleteRepository(ctx context.Context, vcrID, imageName string) error
+	CreateDockerCredentials(ctx context.Context, vcrID string, createOptions *DockerCredentialsOpt) (*ContainerRegistryDockerCredentials, *http.Response, error) //nolint: lll
+}
+
+// ContainerRegistryServiceHandler handles interaction between the container registry service and the Vultr API.
+type ContainerRegistryServiceHandler struct {
+	client *Client
+}
+
+// ContainerRegistry represents a Vultr container registry subscription.
+type ContainerRegistry struct {
+	ID          string                   `json:"id"`
+	Name        string                   `json:"name"`
+	URN         string                   `json:"urn"`
+	Storage     ContainerRegistryStorage `json:"storage"`
+	DateCreated string                   `json:"date_created"`
+	Public      bool                     `json:"public"`
+	RootUser    ContainerRegistryUser    `json:"root_user"`
+}
+
+type containerRegistries struct {
+	ContainerRegistries []ContainerRegistry `json:"registries"`
+	Meta                *Meta               `json:"meta"`
+}
+
+// ContainerRegistryStorage represents the storage usage and limit
+type ContainerRegistryStorage struct {
+	Used    ContainerRegistryStorageCount `json:"used"`
+	Allowed ContainerRegistryStorageCount `json:"allowed"`
+}
+
+// ContainerRegistryStorageCount represents the different storage usage counts
+type ContainerRegistryStorageCount struct {
+	Bytes        float32 `json:"bytes"`
+	MegaBytes    float32 `json:"mb"`
+	GigaBytes    float32 `json:"gb"`
+	TeraBytes    float32 `json:"tb"`
+	DateModified string  `json:"updated_at"`
+}
+
+// ContainerRegistryUser contains the user data
+type ContainerRegistryUser struct {
+	ID           int    `json:"id"`
+	UserName     string `json:"username"`
+	Password     string `json:"password"`
+	Root         bool   `json:"root"`
+	DateCreated  string `json:"added_at"`
+	DateModified string `json:"updated_at"`
+}
+
+// ContainerRegistryReq represents the data used to create a registry
+type ContainerRegistryReq struct {
+	Name   string `json:"name"`
+	Public bool   `json:"public"`
+	Region string `json:"region"`
+	Plan   string `json:"plan"`
+}
+
+// ContainerRegistryReqUpdate represents the data used to update a registry
+type ContainerRegistryReqUpdate struct {
+	Public *bool   `json:"public"`
+	Plan   *string `json:"plan"`
+}
+
+// ContainerRegistryRepo represents the data of a registry repository
+type ContainerRegistryRepo struct {
+	Name          string `json:"name"`
+	Image         string `json:"image"`
+	Description   string `json:"description"`
+	DateCreated   string `json:"added_at"`
+	DateModified  string `json:"updated_at"`
+	PullCount     int    `json:"pull_count"`
+	ArtifactCount int    `json:"artifact_count"`
+}
+
+// ContainerRegistryRepos contains all repos
+type ContainerRegistryRepos struct {
+	Repositories []ContainerRegistryRepo `json:"repositories"`
+	Meta         *Meta                   `json:"meta"`
+}
+
+// ContainerRegistryRepoReqUpdate is the data to update a registry repository
+type ContainerRegistryRepoReqUpdate struct {
+	Description string `json:"description"`
+}
+
+// ContainerRegistryDockerCredential represents the data used to create a Docker credential
+type ContainerRegistryDockerCredentials struct {
+	AuthJSON []byte
+}
+
+// DockerCredentialsOpt contains the options used to create Docker credentials
+type DockerCredentialsOpt struct {
+	ExpirySeconds *int
+	WriteAccess   *bool
+}
+
+// Get retrieves a contrainer registry by ID
+func (h *ContainerRegistryServiceHandler) Get(ctx context.Context, id string) (*ContainerRegistry, *http.Response, error) {
+	req, errReq := h.client.NewRequest(ctx, http.MethodGet, fmt.Sprintf("%s/%s", vcrPath, id), nil)
+	if errReq != nil {
+		return nil, nil, errReq
+	}
+
+	vcr := new(ContainerRegistry)
+	resp, errResp := h.client.DoWithContext(ctx, req, &vcr)
+	if errResp != nil {
+		return nil, resp, errResp
+	}
+
+	return vcr, resp, nil
+}
+
+// List retrieves the list of all container registries
+func (h *ContainerRegistryServiceHandler) List(ctx context.Context, options *ListOptions) ([]ContainerRegistry, *Meta, *http.Response, error) {
+	req, errReq := h.client.NewRequest(ctx, http.MethodGet, vcrListPath, nil)
+	if errReq != nil {
+		return nil, nil, nil, errReq
+	}
+
+	qStrings, errQ := query.Values(options)
+	if errQ != nil {
+		return nil, nil, nil, errQ
+	}
+
+	req.URL.RawQuery = qStrings.Encode()
+
+	vcrs := new(containerRegistries)
+	resp, errResp := h.client.DoWithContext(ctx, req, &vcrs)
+	if errResp != nil {
+		return nil, nil, resp, errResp
+	}
+
+	return vcrs.ContainerRegistries, vcrs.Meta, resp, nil
+}
+
+// Create creates a container registry
+func (h *ContainerRegistryServiceHandler) Create(ctx context.Context, createReq *ContainerRegistryReq) (*ContainerRegistry, *http.Response, error) { //nolint: lll
+	req, errReq := h.client.NewRequest(ctx, http.MethodPost, vcrPath, createReq)
+	if errReq != nil {
+		return nil, nil, errReq
+	}
+
+	vcr := new(ContainerRegistry)
+	resp, errResp := h.client.DoWithContext(ctx, req, &vcr)
+	if errResp != nil {
+		return nil, resp, errResp
+	}
+
+	return vcr, resp, nil
+}
+
+// Update will update an existing container registry
+func (h *ContainerRegistryServiceHandler) Update(ctx context.Context, vcrID string, updateReq *ContainerRegistryReqUpdate) (*ContainerRegistry, *http.Response, error) { //nolint: lll
+	req, errReq := h.client.NewRequest(ctx, http.MethodPut, fmt.Sprintf("%s/%s", vcrPath, vcrID), updateReq)
+	if errReq != nil {
+		return nil, nil, errReq
+	}
+
+	vcr := new(ContainerRegistry)
+	resp, errResp := h.client.DoWithContext(ctx, req, &vcr)
+	if errResp != nil {
+		return nil, resp, errResp
+	}
+
+	return vcr, resp, nil
+}
+
+// Delete will delete a container registry
+func (h *ContainerRegistryServiceHandler) Delete(ctx context.Context, vcrID string) error {
+	req, errReq := h.client.NewRequest(ctx, http.MethodDelete, fmt.Sprintf("%s/%s", vcrPath, vcrID), nil)
+	if errReq != nil {
+		return errReq
+	}
+
+	_, errResp := h.client.DoWithContext(ctx, req, nil)
+	if errResp != nil {
+		return errResp
+	}
+
+	return nil
+}
+
+// ListRepositories will get a list of the repositories for a existing container registry
+func (h *ContainerRegistryServiceHandler) ListRepositories(ctx context.Context, vcrID string, options *ListOptions) ([]ContainerRegistryRepo, *Meta, *http.Response, error) {
+	req, errReq := h.client.NewRequest(ctx, http.MethodGet, fmt.Sprintf("%s/%s/repositories", vcrPath, vcrID), nil)
+	if errReq != nil {
+		return nil, nil, nil, errReq
+	}
+
+	qStrings, errQ := query.Values(options)
+	if errQ != nil {
+		return nil, nil, nil, errQ
+	}
+
+	req.URL.RawQuery = qStrings.Encode()
+
+	vcrRepos := new(ContainerRegistryRepos)
+	resp, errResp := h.client.DoWithContext(ctx, req, &vcrRepos)
+	if errResp != nil {
+		return nil, nil, resp, errResp
+	}
+
+	return vcrRepos.Repositories, vcrRepos.Meta, resp, nil
+}
+
+// GetRepository will return an existing repository of the requested registry ID and image name
+func (h *ContainerRegistryServiceHandler) GetRepository(ctx context.Context, vcrID, imageName string) (*ContainerRegistryRepo, *http.Response, error) {
+	req, errReq := h.client.NewRequest(ctx, http.MethodGet, fmt.Sprintf("%s/%s/repository/%s", vcrPath, vcrID, imageName), nil)
+	if errReq != nil {
+		return nil, nil, errReq
+	}
+
+	vcrRepo := new(ContainerRegistryRepo)
+	resp, errResp := h.client.DoWithContext(ctx, req, &vcrRepo)
+	if errResp != nil {
+		return nil, resp, errResp
+	}
+
+	return vcrRepo, resp, nil
+}
+
+// UpdateRepository allows updating the repository with the specified registry ID and image name
+func (h *ContainerRegistryServiceHandler) UpdateRepository(ctx context.Context, vcrID, imageName string, updateReq *ContainerRegistryRepoReqUpdate) (*ContainerRegistryRepo, *http.Response, error) { //nolint: lll
+	req, errReq := h.client.NewRequest(ctx, http.MethodPut, fmt.Sprintf("%s/%s/repository/%s", vcrPath, vcrID, imageName), updateReq)
+	if errReq != nil {
+		return nil, nil, errReq
+	}
+
+	vcrRepo := new(ContainerRegistryRepo)
+	resp, errResp := h.client.DoWithContext(ctx, req, &vcrRepo)
+	if errResp != nil {
+		return nil, resp, errResp
+	}
+
+	return vcrRepo, resp, nil
+}
+
+// DeleteRepository remove a repository from the container registry
+func (h *ContainerRegistryServiceHandler) DeleteRepository(ctx context.Context, vcrID, imageName string) error {
+	req, errReq := h.client.NewRequest(ctx, http.MethodDelete, fmt.Sprintf("%s/%s/repository/%s", vcrPath, vcrID, imageName), nil)
+	if errReq != nil {
+		return errReq
+	}
+
+	_, errResp := h.client.DoWithContext(ctx, req, nil)
+	if errResp != nil {
+		return errResp
+	}
+
+	return nil
+}
+
+// CreateDockerCredentials will create new Docker credentials used by the Docker CLI
+func (h *ContainerRegistryServiceHandler) CreateDockerCredentials(ctx context.Context, vcrID string, createOptions *DockerCredentialsOpt) (*ContainerRegistryDockerCredentials, *http.Response, error) { //nolint: lll
+	url := fmt.Sprintf("%s/%s/docker-credentials", vcrPath, vcrID)
+	req, errReq := h.client.NewRequest(ctx, http.MethodOptions, url, nil)
+	if errReq != nil {
+		return nil, nil, errReq
+	}
+
+	if createOptions.ExpirySeconds != nil {
+		req.URL.Query().Add("expiry_seconds", fmt.Sprintf("%d", createOptions.ExpirySeconds))
+	}
+
+	if createOptions.WriteAccess != nil {
+		req.URL.Query().Add("read_write", fmt.Sprintf("%t", *createOptions.WriteAccess))
+	}
+
+	// TODO return *http.Response to maintain API
+	resp, errResp := h.client.APIRequest(ctx, req)
+	if errResp != nil {
+		return nil, nil, errResp
+	}
+
+	auth := &ContainerRegistryDockerCredentials{AuthJSON: resp.BodyBytes}
+
+	// TODO return *http.Response to maintain API
+	return auth, nil, nil
+}

--- a/container_registry.go
+++ b/container_registry.go
@@ -121,8 +121,7 @@ type ContainerRegistryRepo struct {
 	ArtifactCount int    `json:"artifact_count"`
 }
 
-// ContainerRegistryRepos contains all repos
-type ContainerRegistryRepos struct {
+type containerRegistryRepos struct {
 	Repositories []ContainerRegistryRepo `json:"repositories"`
 	Meta         *Meta                   `json:"meta"`
 }
@@ -301,7 +300,7 @@ func (h *ContainerRegistryServiceHandler) ListRepositories(ctx context.Context, 
 
 	req.URL.RawQuery = qStrings.Encode()
 
-	vcrRepos := new(ContainerRegistryRepos)
+	vcrRepos := new(containerRegistryRepos)
 	resp, errResp := h.client.DoWithContext(ctx, req, &vcrRepos)
 	if errResp != nil {
 		return nil, nil, resp, errResp

--- a/container_registry.go
+++ b/container_registry.go
@@ -22,7 +22,7 @@ type ContainerRegistryService interface {
 	List(ctx context.Context, options *ListOptions) ([]ContainerRegistry, *Meta, *http.Response, error)
 	ListRepositories(ctx context.Context, vcrID string, options *ListOptions) ([]ContainerRegistryRepo, *Meta, *http.Response, error)
 	GetRepository(ctx context.Context, vcrID, imageName string) (*ContainerRegistryRepo, *http.Response, error)
-	UpdateRepository(ctx context.Context, vcrID, imageName string, updateReq *ContainerRegistryRepoReqUpdate) (*ContainerRegistryRepo, *http.Response, error) //nolint:lll
+	UpdateRepository(ctx context.Context, vcrID, imageName string, updateReq *ContainerRegistryRepoUpdateReq) (*ContainerRegistryRepo, *http.Response, error) //nolint:lll
 	DeleteRepository(ctx context.Context, vcrID, imageName string) error
 	CreateDockerCredentials(ctx context.Context, vcrID string, createOptions *DockerCredentialsOpt) (*ContainerRegistryDockerCredentials, *http.Response, error) //nolint:lll
 	ListRegions(ctx context.Context, options *ListOptions) ([]ContainerRegistryRegion, *Meta, *http.Response, error)
@@ -126,8 +126,8 @@ type containerRegistryRepos struct {
 	Meta         *Meta                   `json:"meta"`
 }
 
-// ContainerRegistryRepoReqUpdate is the data to update a registry repository
-type ContainerRegistryRepoReqUpdate struct {
+// ContainerRegistryRepoUpdateReq is the data to update a registry repository
+type ContainerRegistryRepoUpdateReq struct {
 	Description string `json:"description"`
 }
 
@@ -328,7 +328,7 @@ func (h *ContainerRegistryServiceHandler) GetRepository(ctx context.Context, vcr
 
 // UpdateRepository allows updating the repository with the specified registry
 // ID and image name
-func (h *ContainerRegistryServiceHandler) UpdateRepository(ctx context.Context, vcrID, imageName string, updateReq *ContainerRegistryRepoReqUpdate) (*ContainerRegistryRepo, *http.Response, error) { //nolint: lll
+func (h *ContainerRegistryServiceHandler) UpdateRepository(ctx context.Context, vcrID, imageName string, updateReq *ContainerRegistryRepoUpdateReq) (*ContainerRegistryRepo, *http.Response, error) { //nolint: lll
 	req, errReq := h.client.NewRequest(ctx, http.MethodPut, fmt.Sprintf("%s/%s/repository/%s", vcrPath, vcrID, imageName), updateReq)
 	if errReq != nil {
 		return nil, nil, errReq

--- a/container_registry.go
+++ b/container_registry.go
@@ -17,7 +17,7 @@ const vcrListPath = "/v2/registries"
 type ContainerRegistryService interface {
 	Create(ctx context.Context, createReq *ContainerRegistryReq) (*ContainerRegistry, *http.Response, error)
 	Get(ctx context.Context, vcrID string) (*ContainerRegistry, *http.Response, error)
-	Update(ctx context.Context, vcrID string, updateReq *ContainerRegistryReqUpdate) (*ContainerRegistry, *http.Response, error)
+	Update(ctx context.Context, vcrID string, updateReq *ContainerRegistryUpdateReq) (*ContainerRegistry, *http.Response, error)
 	Delete(ctx context.Context, vcrID string) error
 	List(ctx context.Context, options *ListOptions) ([]ContainerRegistry, *Meta, *http.Response, error)
 	ListRepositories(ctx context.Context, vcrID string, options *ListOptions) ([]ContainerRegistryRepo, *Meta, *http.Response, error)
@@ -104,8 +104,8 @@ type ContainerRegistryReq struct {
 	Plan   string `json:"plan"`
 }
 
-// ContainerRegistryReqUpdate represents the data used to update a registry
-type ContainerRegistryReqUpdate struct {
+// ContainerRegistryUpdateReq represents the data used to update a registry
+type ContainerRegistryUpdateReq struct {
 	Public *bool   `json:"public"`
 	Plan   *string `json:"plan"`
 }
@@ -256,7 +256,7 @@ func (h *ContainerRegistryServiceHandler) Create(ctx context.Context, createReq 
 }
 
 // Update will update an existing container registry
-func (h *ContainerRegistryServiceHandler) Update(ctx context.Context, vcrID string, updateReq *ContainerRegistryReqUpdate) (*ContainerRegistry, *http.Response, error) { //nolint:lll
+func (h *ContainerRegistryServiceHandler) Update(ctx context.Context, vcrID string, updateReq *ContainerRegistryUpdateReq) (*ContainerRegistry, *http.Response, error) { //nolint:lll
 	req, errReq := h.client.NewRequest(ctx, http.MethodPut, fmt.Sprintf("%s/%s", vcrPath, vcrID), updateReq)
 	if errReq != nil {
 		return nil, nil, errReq

--- a/container_registry.go
+++ b/container_registry.go
@@ -37,13 +37,14 @@ type ContainerRegistryServiceHandler struct {
 
 // ContainerRegistry represents a Vultr container registry subscription.
 type ContainerRegistry struct {
-	ID          string                   `json:"id"`
-	Name        string                   `json:"name"`
-	URN         string                   `json:"urn"`
-	Storage     ContainerRegistryStorage `json:"storage"`
-	DateCreated string                   `json:"date_created"`
-	Public      bool                     `json:"public"`
-	RootUser    ContainerRegistryUser    `json:"root_user"`
+	ID          string                    `json:"id"`
+	Name        string                    `json:"name"`
+	URN         string                    `json:"urn"`
+	Storage     ContainerRegistryStorage  `json:"storage"`
+	DateCreated string                    `json:"date_created"`
+	Public      bool                      `json:"public"`
+	RootUser    ContainerRegistryUser     `json:"root_user"`
+	Metadata    ContainerRegistryMetadata `json:"metadata"`
 }
 
 type containerRegistries struct {
@@ -74,6 +75,25 @@ type ContainerRegistryUser struct {
 	Root         bool   `json:"root"`
 	DateCreated  string `json:"added_at"`
 	DateModified string `json:"updated_at"`
+}
+
+// ContainerRegistryMetadata contains the meta data for the registry
+type ContainerRegistryMetadata struct {
+	Region       ContainerRegistryRegion       `json:"region"`
+	Subscription ContainerRegistrySubscription `json:"subscription"`
+}
+
+// ContainerRegistrySubscription contains the subscription information for the
+// registry
+type ContainerRegistrySubscription struct {
+	Billing ContainerRegistrySubscriptionBilling `json:"billing"`
+}
+
+// ContainerRegistrySubscriptionBilling represents the subscription billing
+// data on the registry
+type ContainerRegistrySubscriptionBilling struct {
+	MonthlyPrice   float32 `json:"monthly_price"`
+	PendingCharges float32 `json:"pending_charges"`
 }
 
 // ContainerRegistryReq represents the data used to create a registry

--- a/container_registry.go
+++ b/container_registry.go
@@ -11,8 +11,9 @@ import (
 const vcrPath = "/v2/registry"
 const vcrListPath = "/v2/registries"
 
-// ContainerRegistryService is the interface to interact with the container registry endpoints on the Vultr API.
-// Link : https://www.vultr.com/api/#tag/Container-Registry
+// ContainerRegistryService is the interface to interact with the container
+// registry endpoints on the Vultr API.  Link :
+// https://www.vultr.com/api/#tag/Container-Registry
 type ContainerRegistryService interface {
 	Create(ctx context.Context, createReq *ContainerRegistryReq) (*ContainerRegistry, *http.Response, error)
 	Get(ctx context.Context, vcrID string) (*ContainerRegistry, *http.Response, error)
@@ -21,14 +22,15 @@ type ContainerRegistryService interface {
 	List(ctx context.Context, options *ListOptions) ([]ContainerRegistry, *Meta, *http.Response, error)
 	ListRepositories(ctx context.Context, vcrID string, options *ListOptions) ([]ContainerRegistryRepo, *Meta, *http.Response, error)
 	GetRepository(ctx context.Context, vcrID, imageName string) (*ContainerRegistryRepo, *http.Response, error)
-	UpdateRepository(ctx context.Context, vcrID, imageName string, updateReq *ContainerRegistryRepoReqUpdate) (*ContainerRegistryRepo, *http.Response, error)
+	UpdateRepository(ctx context.Context, vcrID, imageName string, updateReq *ContainerRegistryRepoReqUpdate) (*ContainerRegistryRepo, *http.Response, error) //nolint:lll
 	DeleteRepository(ctx context.Context, vcrID, imageName string) error
-	// CreateDockerCredentials(ctx context.Context, vcrID string, createOptions *DockerCredentialsOpt) (*ContainerRegistryDockerCredentials, *http.Response, error) //nolint: lll
+	CreateDockerCredentials(ctx context.Context, vcrID string, createOptions *DockerCredentialsOpt) (*ContainerRegistryDockerCredentials, *http.Response, error) //nolint:lll
 	ListRegions(ctx context.Context, options *ListOptions) ([]ContainerRegistryRegion, *Meta, *http.Response, error)
 	ListPlans(ctx context.Context) (*ContainerRegistryPlans, *http.Response, error)
 }
 
-// ContainerRegistryServiceHandler handles interaction between the container registry service and the Vultr API.
+// ContainerRegistryServiceHandler handles interaction between the container
+// registry service and the Vultr API.
 type ContainerRegistryServiceHandler struct {
 	client *Client
 }
@@ -110,16 +112,27 @@ type ContainerRegistryRepoReqUpdate struct {
 	Description string `json:"description"`
 }
 
-// ContainerRegistryDockerCredential represents the data used to create a Docker credential
-type ContainerRegistryDockerCredentials struct {
-	AuthJSON []byte
+// ContainerRegistryDockerCredentials represents the byte array of character
+// data returned after creating a Docker credential
+type ContainerRegistryDockerCredentials []byte
+
+// UnmarshalJSON is a custom unmarshal function for
+// ContainerRegistryDockerCredentials
+func (c *ContainerRegistryDockerCredentials) UnmarshalJSON(b []byte) error {
+	*c = b
+	return nil
+}
+
+// String converts the ContainerRegistryDockerCredentials to a string
+func (c *ContainerRegistryDockerCredentials) String() string {
+	return string(*c)
 }
 
 // DockerCredentialsOpt contains the options used to create Docker credentials
-// type DockerCredentialsOpt struct {
-// 	ExpirySeconds *int
-// 	WriteAccess   *bool
-// }
+type DockerCredentialsOpt struct {
+	ExpirySeconds *int
+	WriteAccess   *bool
+}
 
 // ContainerRegistryRegion represents the region data
 type ContainerRegistryRegion struct {
@@ -171,7 +184,7 @@ func (h *ContainerRegistryServiceHandler) Get(ctx context.Context, id string) (*
 }
 
 // List retrieves the list of all container registries
-func (h *ContainerRegistryServiceHandler) List(ctx context.Context, options *ListOptions) ([]ContainerRegistry, *Meta, *http.Response, error) {
+func (h *ContainerRegistryServiceHandler) List(ctx context.Context, options *ListOptions) ([]ContainerRegistry, *Meta, *http.Response, error) { //nolint:lll,dupl
 	req, errReq := h.client.NewRequest(ctx, http.MethodGet, vcrListPath, nil)
 	if errReq != nil {
 		return nil, nil, nil, errReq
@@ -194,7 +207,7 @@ func (h *ContainerRegistryServiceHandler) List(ctx context.Context, options *Lis
 }
 
 // Create creates a container registry
-func (h *ContainerRegistryServiceHandler) Create(ctx context.Context, createReq *ContainerRegistryReq) (*ContainerRegistry, *http.Response, error) { //nolint: lll
+func (h *ContainerRegistryServiceHandler) Create(ctx context.Context, createReq *ContainerRegistryReq) (*ContainerRegistry, *http.Response, error) { //nolint:lll
 	req, errReq := h.client.NewRequest(ctx, http.MethodPost, vcrPath, createReq)
 	if errReq != nil {
 		return nil, nil, errReq
@@ -210,7 +223,7 @@ func (h *ContainerRegistryServiceHandler) Create(ctx context.Context, createReq 
 }
 
 // Update will update an existing container registry
-func (h *ContainerRegistryServiceHandler) Update(ctx context.Context, vcrID string, updateReq *ContainerRegistryReqUpdate) (*ContainerRegistry, *http.Response, error) { //nolint: lll
+func (h *ContainerRegistryServiceHandler) Update(ctx context.Context, vcrID string, updateReq *ContainerRegistryReqUpdate) (*ContainerRegistry, *http.Response, error) { //nolint:lll
 	req, errReq := h.client.NewRequest(ctx, http.MethodPut, fmt.Sprintf("%s/%s", vcrPath, vcrID), updateReq)
 	if errReq != nil {
 		return nil, nil, errReq
@@ -240,8 +253,9 @@ func (h *ContainerRegistryServiceHandler) Delete(ctx context.Context, vcrID stri
 	return nil
 }
 
-// ListRepositories will get a list of the repositories for a existing container registry
-func (h *ContainerRegistryServiceHandler) ListRepositories(ctx context.Context, vcrID string, options *ListOptions) ([]ContainerRegistryRepo, *Meta, *http.Response, error) {
+// ListRepositories will get a list of the repositories for a existing
+// container registry
+func (h *ContainerRegistryServiceHandler) ListRepositories(ctx context.Context, vcrID string, options *ListOptions) ([]ContainerRegistryRepo, *Meta, *http.Response, error) { //nolint:lll,dupl
 	req, errReq := h.client.NewRequest(ctx, http.MethodGet, fmt.Sprintf("%s/%s/repositories", vcrPath, vcrID), nil)
 	if errReq != nil {
 		return nil, nil, nil, errReq
@@ -263,8 +277,9 @@ func (h *ContainerRegistryServiceHandler) ListRepositories(ctx context.Context, 
 	return vcrRepos.Repositories, vcrRepos.Meta, resp, nil
 }
 
-// GetRepository will return an existing repository of the requested registry ID and image name
-func (h *ContainerRegistryServiceHandler) GetRepository(ctx context.Context, vcrID, imageName string) (*ContainerRegistryRepo, *http.Response, error) {
+// GetRepository will return an existing repository of the requested registry
+// ID and image name
+func (h *ContainerRegistryServiceHandler) GetRepository(ctx context.Context, vcrID, imageName string) (*ContainerRegistryRepo, *http.Response, error) { //nolint:lll
 	req, errReq := h.client.NewRequest(ctx, http.MethodGet, fmt.Sprintf("%s/%s/repository/%s", vcrPath, vcrID, imageName), nil)
 	if errReq != nil {
 		return nil, nil, errReq
@@ -279,7 +294,8 @@ func (h *ContainerRegistryServiceHandler) GetRepository(ctx context.Context, vcr
 	return vcrRepo, resp, nil
 }
 
-// UpdateRepository allows updating the repository with the specified registry ID and image name
+// UpdateRepository allows updating the repository with the specified registry
+// ID and image name
 func (h *ContainerRegistryServiceHandler) UpdateRepository(ctx context.Context, vcrID, imageName string, updateReq *ContainerRegistryRepoReqUpdate) (*ContainerRegistryRepo, *http.Response, error) { //nolint: lll
 	req, errReq := h.client.NewRequest(ctx, http.MethodPut, fmt.Sprintf("%s/%s/repository/%s", vcrPath, vcrID, imageName), updateReq)
 	if errReq != nil {
@@ -310,36 +326,39 @@ func (h *ContainerRegistryServiceHandler) DeleteRepository(ctx context.Context, 
 	return nil
 }
 
-// CreateDockerCredentials will create new Docker credentials used by the Docker CLI
-// func (h *ContainerRegistryServiceHandler) CreateDockerCredentials(ctx context.Context, vcrID string, createOptions *DockerCredentialsOpt) (*ContainerRegistryDockerCredentials, *http.Response, error) { //nolint: lll
-// 	url := fmt.Sprintf("%s/%s/docker-credentials", vcrPath, vcrID)
-// 	req, errReq := h.client.NewRequest(ctx, http.MethodOptions, url, nil)
-// 	if errReq != nil {
-// 		return nil, nil, errReq
-// 	}
+// CreateDockerCredentials will create new Docker credentials used by the
+// Docker CLI
+func (h *ContainerRegistryServiceHandler) CreateDockerCredentials(ctx context.Context, vcrID string, createOptions *DockerCredentialsOpt) (*ContainerRegistryDockerCredentials, *http.Response, error) { //nolint:lll
+	url := fmt.Sprintf("%s/%s/docker-credentials", vcrPath, vcrID)
+	req, errReq := h.client.NewRequest(ctx, http.MethodOptions, url, nil)
+	if errReq != nil {
+		return nil, nil, errReq
+	}
 
-// 	if createOptions.ExpirySeconds != nil {
-// 		req.URL.Query().Add("expiry_seconds", fmt.Sprintf("%d", createOptions.ExpirySeconds))
-// 	}
+	queryParam := req.URL.Query()
+	if createOptions.ExpirySeconds != nil {
+		queryParam.Add("expiry_seconds", fmt.Sprintf("%d", createOptions.ExpirySeconds))
+	}
 
-// 	if createOptions.WriteAccess != nil {
-// 		req.URL.Query().Add("read_write", fmt.Sprintf("%t", *createOptions.WriteAccess))
-// 	}
+	if createOptions.WriteAccess != nil {
+		queryParam.Add("read_write", fmt.Sprintf("%t", *createOptions.WriteAccess))
+	}
 
-// 	// TODO return *http.Response to maintain API
-// 	resp, errResp := h.client.DoWithContext(ctx, req, nil)
-// 	if errResp != nil {
-// 		return nil, nil, errResp
-// 	}
+	req.URL.RawQuery = queryParam.Encode()
 
-// 	auth := &ContainerRegistryDockerCredentials{AuthJSON: resp.BodyBytes}
+	creds := new(ContainerRegistryDockerCredentials)
+	// TODO return *http.Response to maintain API
+	resp, errResp := h.client.DoWithContext(ctx, req, &creds)
+	if errResp != nil {
+		return nil, nil, errResp
+	}
 
-// 	// TODO return *http.Response to maintain API
-// 	return auth, nil, nil
-// }
+	return creds, resp, nil
+}
 
-// ListRegions(ctx context.Context, options *ListOptions) ([]ContainerRegistryRegion, *Meta, *http.Response, error)
-func (h *ContainerRegistryServiceHandler) ListRegions(ctx context.Context, options *ListOptions) ([]ContainerRegistryRegion, *Meta, *http.Response, error) {
+// ListRegions will return a list of regions relevant to the container registry
+// API operations
+func (h *ContainerRegistryServiceHandler) ListRegions(ctx context.Context, options *ListOptions) ([]ContainerRegistryRegion, *Meta, *http.Response, error) { //nolint:lll
 	req, errReq := h.client.NewRequest(ctx, http.MethodGet, fmt.Sprintf("%s/region/list", vcrPath), nil)
 	if errReq != nil {
 		return nil, nil, nil, errReq
@@ -354,7 +373,8 @@ func (h *ContainerRegistryServiceHandler) ListRegions(ctx context.Context, optio
 	return vcrRegions.Regions, vcrRegions.Meta, resp, nil
 }
 
-// ListPlans(ctx context.Context, options *ListOptions) (ContainerRegistryPlans, *http.Response, error)
+// ListPlans returns a list of plans relevant to the container registry
+// offerings
 func (h *ContainerRegistryServiceHandler) ListPlans(ctx context.Context) (*ContainerRegistryPlans, *http.Response, error) {
 	req, errReq := h.client.NewRequest(ctx, http.MethodGet, fmt.Sprintf("%s/plan/list", vcrPath), nil)
 	if errReq != nil {

--- a/container_registry.go
+++ b/container_registry.go
@@ -347,7 +347,6 @@ func (h *ContainerRegistryServiceHandler) CreateDockerCredentials(ctx context.Co
 	req.URL.RawQuery = queryParam.Encode()
 
 	creds := new(ContainerRegistryDockerCredentials)
-	// TODO return *http.Response to maintain API
 	resp, errResp := h.client.DoWithContext(ctx, req, &creds)
 	if errResp != nil {
 		return nil, nil, errResp

--- a/container_registry.go
+++ b/container_registry.go
@@ -156,13 +156,26 @@ func (c *ContainerRegistryDockerCredentials) String() string {
 
 // ContainerRegistryRegion represents the region data
 type ContainerRegistryRegion struct {
-	ID           int    `json:"id"`
-	Name         string `json:"name"`
-	URN          string `json:"urn"`
-	BaseURL      string `json:"base_url"`
-	Public       bool   `json:"public"`
-	DateCreated  string `json:"added_at"`
-	DateModified string `json:"updated_at"`
+	ID           int                               `json:"id"`
+	Name         string                            `json:"name"`
+	URN          string                            `json:"urn"`
+	BaseURL      string                            `json:"base_url"`
+	Public       bool                              `json:"public"`
+	DateCreated  string                            `json:"added_at"`
+	DateModified string                            `json:"updated_at"`
+	DataCenter   ContainerRegistryRegionDataCenter `json:"data_center"`
+}
+
+// ContainerRegistryRegionDataCenter is the datacenter info for a given region
+type ContainerRegistryRegionDataCenter struct {
+	ID          int    `json:"id"`
+	Name        string `json:"name"`
+	SiteCode    string `json:"site_code"`
+	Region      string `json:"region"`
+	Country     string `json:"country"`
+	Continent   string `json:"continent"`
+	Description string `json:"description"`
+	Airport     string `json:"airport"`
 }
 
 type containerRegistryRegions struct {

--- a/container_registry.go
+++ b/container_registry.go
@@ -112,6 +112,12 @@ type ContainerRegistryRepoReqUpdate struct {
 	Description string `json:"description"`
 }
 
+// DockerCredentialsOpt contains the options used to create Docker credentials
+type DockerCredentialsOpt struct {
+	ExpirySeconds *int
+	WriteAccess   *bool
+}
+
 // ContainerRegistryDockerCredentials represents the byte array of character
 // data returned after creating a Docker credential
 type ContainerRegistryDockerCredentials []byte
@@ -126,12 +132,6 @@ func (c *ContainerRegistryDockerCredentials) UnmarshalJSON(b []byte) error {
 // String converts the ContainerRegistryDockerCredentials to a string
 func (c *ContainerRegistryDockerCredentials) String() string {
 	return string(*c)
-}
-
-// DockerCredentialsOpt contains the options used to create Docker credentials
-type DockerCredentialsOpt struct {
-	ExpirySeconds *int
-	WriteAccess   *bool
 }
 
 // ContainerRegistryRegion represents the region data

--- a/container_registry.go
+++ b/container_registry.go
@@ -182,14 +182,17 @@ type containerRegistryRegions struct {
 	Meta    *Meta                     `json:"meta"`
 }
 
-// ContainerRegistryPlans represent the different plan types
+// ContainerRegistryPlans contains all plan types
 type ContainerRegistryPlans struct {
-	Plans struct {
-		StartUp    ContainerRegistryPlan `json:"start_up"`
-		Business   ContainerRegistryPlan `json:"business"`
-		Premium    ContainerRegistryPlan `json:"premium"`
-		Enterprise ContainerRegistryPlan `json:"enterprise"`
-	} `json:"plans"`
+	Plans ContainerRegistryPlanTypes `json:"plans"`
+}
+
+// ContainerRegistryPlanTypes represent the different plan types
+type ContainerRegistryPlanTypes struct {
+	StartUp    ContainerRegistryPlan `json:"start_up"`
+	Business   ContainerRegistryPlan `json:"business"`
+	Premium    ContainerRegistryPlan `json:"premium"`
+	Enterprise ContainerRegistryPlan `json:"enterprise"`
 }
 
 // ContainerRegistryPlan represent the plan data

--- a/container_registry_test.go
+++ b/container_registry_test.go
@@ -1,0 +1,1095 @@
+package govultr
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestVCRServiceHandler_Create(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc(vcrPath, func(writer http.ResponseWriter, request *http.Request) {
+		response := `{
+    "id": "e1d6be16-2b0c-4d76-a3eb-f28bf6ea5fe0",
+    "name": "govultrtest",
+    "region": "sjc",
+    "urn": "sjc.vultrcr.com/govultrtest",
+    "storage": {
+        "used": {
+            "updated_at": "2023-11-09 13:37:12",
+            "bytes": 0,
+            "mb": 0,
+            "gb": 0,
+            "tb": 0
+        },
+        "allowed": {
+            "bytes": 21474836480,
+            "mb": 20480,
+            "gb": 20,
+            "tb": 0.02
+        }
+    },
+    "date_created": "2023-11-09 13:37:12",
+    "public": false,
+    "root_user": {
+        "id": 635,
+        "username": "e1d6be16-2b0c-4d76-a3eb-f28bf6ea5fe0",
+        "password": "5dEr33smkSYauMmRWusNFk9HpweL5CevpnFr",
+        "root": true,
+        "added_at": "2023-11-09 13:37:12",
+        "updated_at": "2023-11-09 13:37:12"
+    },
+    "metadata": {
+        "region": {
+            "id": 3,
+            "name": "sjc",
+            "urn": "sjc.vultrcr.com",
+            "base_url": "https://sjc.vultrcr.com",
+            "public": true,
+            "added_at": "2023-09-14 09:09:16",
+            "updated_at": "2023-09-14 09:09:16",
+            "data_center": {
+                "id": 12,
+                "name": "Silicon Valley",
+                "site_code": "SJC2",
+                "region": "West",
+                "country": "US",
+                "continent": "North America",
+                "description": "Silicon Valley, California",
+                "airport": "SJC"
+            }
+        },
+        "subscription": {
+            "billing": {
+                "monthly_price": 5,
+                "pending_charges": 0
+            }
+        }
+    }
+}`
+		fmt.Fprint(writer, response)
+	})
+
+	req := &ContainerRegistryReq{
+		Name:   "govultrtest",
+		Public: false,
+		Region: "sjc",
+		Plan:   "business",
+	}
+
+	vcr, _, err := client.ContainerRegistry.Create(ctx, req)
+	if err != nil {
+		t.Errorf("ContainerRegistry.Create returned %v", err)
+	}
+
+	expected := &ContainerRegistry{
+		ID:   "e1d6be16-2b0c-4d76-a3eb-f28bf6ea5fe0",
+		Name: "govultrtest",
+		URN:  "sjc.vultrcr.com/govultrtest",
+		Storage: ContainerRegistryStorage{
+			Used: ContainerRegistryStorageCount{
+				Bytes:        0,
+				MegaBytes:    0,
+				GigaBytes:    0,
+				TeraBytes:    0,
+				DateModified: "2023-11-09 13:37:12",
+			},
+			Allowed: ContainerRegistryStorageCount{
+				Bytes:        21474836480,
+				MegaBytes:    20480,
+				GigaBytes:    20,
+				TeraBytes:    0.02,
+				DateModified: "",
+			},
+		},
+		DateCreated: "2023-11-09 13:37:12",
+		Public:      false,
+		RootUser: ContainerRegistryUser{
+			ID:           635,
+			UserName:     "e1d6be16-2b0c-4d76-a3eb-f28bf6ea5fe0",
+			Password:     "5dEr33smkSYauMmRWusNFk9HpweL5CevpnFr",
+			Root:         true,
+			DateCreated:  "2023-11-09 13:37:12",
+			DateModified: "2023-11-09 13:37:12",
+		},
+		Metadata: ContainerRegistryMetadata{
+			Region: ContainerRegistryRegion{
+				ID:           3,
+				Name:         "sjc",
+				URN:          "sjc.vultrcr.com",
+				BaseURL:      "https://sjc.vultrcr.com",
+				Public:       true,
+				DateCreated:  "2023-09-14 09:09:16",
+				DateModified: "2023-09-14 09:09:16",
+				DataCenter: ContainerRegistryRegionDataCenter{
+					ID:          12,
+					Name:        "Silicon Valley",
+					SiteCode:    "SJC2",
+					Region:      "West",
+					Country:     "US",
+					Continent:   "North America",
+					Description: "Silicon Valley, California",
+					Airport:     "SJC",
+				},
+			},
+			Subscription: ContainerRegistrySubscription{
+				Billing: ContainerRegistrySubscriptionBilling{
+					MonthlyPrice:   5,
+					PendingCharges: 0,
+				},
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(vcr, expected) {
+		t.Errorf("ContainerRegistry.Create returned %+v, expected %+v", vcr, expected)
+	}
+
+	c, can := context.WithTimeout(ctx, 1*time.Microsecond)
+	defer can()
+	_, _, err = client.ContainerRegistry.Create(c, req)
+	if err == nil {
+		t.Error("ContainerRegistry.Create returned nil")
+	}
+}
+
+func TestVCRServiceHandler_List(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc(vcrListPath, func(writer http.ResponseWriter, request *http.Request) {
+		response := `{
+    "registries": [
+        {
+            "id": "297cfaff-cb5a-4b7c-ac2e-407fcdbd643e",
+            "name": "govultrtest",
+            "region": "sjc",
+            "urn": "sjc.vultrcr.com/govultrtest",
+            "storage": {
+                "used": {
+                    "updated_at": "2023-11-09 23:09:24",
+                    "bytes": 0,
+                    "mb": 0,
+                    "gb": 0,
+                    "tb": 0
+                },
+                "allowed": {
+                    "bytes": 21474836480,
+                    "mb": 20480,
+                    "gb": 20,
+                    "tb": 0.02
+                }
+            },
+            "date_created": "2023-11-09 17:32:17",
+            "public": true,
+            "root_user": {
+                "id": 639,
+                "username": "297cfaff-cb5a-4b7c-ac2e-407fcdbd643e",
+                "password": "Je2S9SkjrowwMtP933SSaxZG4BPR7D8Au33P",
+                "root": true,
+                "added_at": "2023-11-09 17:32:17",
+                "updated_at": "2023-11-09 17:32:17"
+            },
+            "metadata": {
+                "region": {
+                    "id": 3,
+                    "name": "sjc",
+                    "urn": "sjc.vultrcr.com",
+                    "base_url": "https://sjc.vultrcr.com",
+                    "public": true,
+                    "added_at": "2023-09-14 09:09:16",
+                    "updated_at": "2023-09-14 09:09:16",
+                    "data_center": {
+                        "id": 12,
+                        "name": "Silicon Valley",
+                        "site_code": "SJC2",
+                        "region": "West",
+                        "country": "US",
+                        "continent": "North America",
+                        "description": "Silicon Valley, California",
+                        "airport": "SJC"
+                    }
+                },
+                "subscription": {
+                    "billing": {
+                        "monthly_price": 5,
+                        "pending_charges": 0.01
+                    }
+                }
+            }
+        },
+        {
+            "id": "c247a5d7-b3e1-468c-bcba-c23d0716ffc8",
+            "name": "govultrtest2",
+            "region": "sjc",
+            "urn": "sjc.vultrcr.com/govultrtest2",
+            "storage": {
+                "used": {
+                    "updated_at": "2023-11-09 23:09:24",
+                    "bytes": 0,
+                    "mb": 0,
+                    "gb": 0,
+                    "tb": 0
+                },
+                "allowed": {
+                    "bytes": 21474836480,
+                    "mb": 20480,
+                    "gb": 20,
+                    "tb": 0.02
+                }
+            },
+            "date_created": "2023-11-09 17:33:13",
+            "public": true,
+            "root_user": {
+                "id": 640,
+                "username": "c247a5d7-b3e1-468c-bcba-c23d0716ffc8",
+                "password": "c9NhkeH7aeF7zj3cRFHbMFizxEik4rhWYGdW",
+                "root": true,
+                "added_at": "2023-11-09 17:33:13",
+                "updated_at": "2023-11-09 17:33:13"
+            },
+            "metadata": {
+                "region": {
+                    "id": 3,
+                    "name": "sjc",
+                    "urn": "sjc.vultrcr.com",
+                    "base_url": "https://sjc.vultrcr.com",
+                    "public": true,
+                    "added_at": "2023-09-14 09:09:16",
+                    "updated_at": "2023-09-14 09:09:16",
+                    "data_center": {
+                        "id": 12,
+                        "name": "Silicon Valley",
+                        "site_code": "SJC2",
+                        "region": "West",
+                        "country": "US",
+                        "continent": "North America",
+                        "description": "Silicon Valley, California",
+                        "airport": "SJC"
+                    }
+                },
+                "subscription": {
+                    "billing": {
+                        "monthly_price": 5,
+                        "pending_charges": 0.01
+                    }
+                }
+            }
+        }
+    ],
+    "meta": {
+        "total": 2,
+        "links": {
+            "next": "",
+            "prev": ""
+        }
+    }
+}`
+		fmt.Fprint(writer, response)
+	})
+
+	vcrs, meta, _, err := client.ContainerRegistry.List(ctx, nil)
+	if err != nil {
+		t.Errorf("ContainerRegistry.List returned %+v", err)
+	}
+
+	expected := []ContainerRegistry{
+		{
+			ID:   "297cfaff-cb5a-4b7c-ac2e-407fcdbd643e",
+			Name: "govultrtest",
+			URN:  "sjc.vultrcr.com/govultrtest",
+			Storage: ContainerRegistryStorage{
+				Used: ContainerRegistryStorageCount{
+					Bytes:        0,
+					MegaBytes:    0,
+					GigaBytes:    0,
+					TeraBytes:    0,
+					DateModified: "2023-11-09 23:09:24",
+				},
+				Allowed: ContainerRegistryStorageCount{
+					Bytes:        21474836480,
+					MegaBytes:    20480,
+					GigaBytes:    20,
+					TeraBytes:    0.02,
+					DateModified: "",
+				},
+			},
+			DateCreated: "2023-11-09 17:32:17",
+			Public:      true,
+			RootUser: ContainerRegistryUser{
+				ID:           639,
+				UserName:     "297cfaff-cb5a-4b7c-ac2e-407fcdbd643e",
+				Password:     "Je2S9SkjrowwMtP933SSaxZG4BPR7D8Au33P",
+				Root:         true,
+				DateCreated:  "2023-11-09 17:32:17",
+				DateModified: "2023-11-09 17:32:17",
+			},
+			Metadata: ContainerRegistryMetadata{
+				Region: ContainerRegistryRegion{
+					ID:           3,
+					Name:         "sjc",
+					URN:          "sjc.vultrcr.com",
+					BaseURL:      "https://sjc.vultrcr.com",
+					Public:       true,
+					DateCreated:  "2023-09-14 09:09:16",
+					DateModified: "2023-09-14 09:09:16",
+					DataCenter: ContainerRegistryRegionDataCenter{
+						ID:          12,
+						Name:        "Silicon Valley",
+						SiteCode:    "SJC2",
+						Region:      "West",
+						Country:     "US",
+						Continent:   "North America",
+						Description: "Silicon Valley, California",
+						Airport:     "SJC",
+					},
+				},
+				Subscription: ContainerRegistrySubscription{
+					Billing: ContainerRegistrySubscriptionBilling{
+						MonthlyPrice:   5,
+						PendingCharges: 0.01,
+					},
+				},
+			},
+		},
+		{
+			ID:   "c247a5d7-b3e1-468c-bcba-c23d0716ffc8",
+			Name: "govultrtest2",
+			URN:  "sjc.vultrcr.com/govultrtest2",
+			Storage: ContainerRegistryStorage{
+				Used: ContainerRegistryStorageCount{
+					Bytes:        0,
+					MegaBytes:    0,
+					GigaBytes:    0,
+					TeraBytes:    0,
+					DateModified: "2023-11-09 23:09:24",
+				},
+				Allowed: ContainerRegistryStorageCount{
+					Bytes:        21474836480,
+					MegaBytes:    20480,
+					GigaBytes:    20,
+					TeraBytes:    0.02,
+					DateModified: "",
+				},
+			},
+			DateCreated: "2023-11-09 17:33:13",
+			Public:      true,
+			RootUser: ContainerRegistryUser{
+				ID:           640,
+				UserName:     "c247a5d7-b3e1-468c-bcba-c23d0716ffc8",
+				Password:     "c9NhkeH7aeF7zj3cRFHbMFizxEik4rhWYGdW",
+				Root:         true,
+				DateCreated:  "2023-11-09 17:33:13",
+				DateModified: "2023-11-09 17:33:13",
+			},
+			Metadata: ContainerRegistryMetadata{
+				Region: ContainerRegistryRegion{
+					ID:           3,
+					Name:         "sjc",
+					URN:          "sjc.vultrcr.com",
+					BaseURL:      "https://sjc.vultrcr.com",
+					Public:       true,
+					DateCreated:  "2023-09-14 09:09:16",
+					DateModified: "2023-09-14 09:09:16",
+					DataCenter: ContainerRegistryRegionDataCenter{
+						ID:          12,
+						Name:        "Silicon Valley",
+						SiteCode:    "SJC2",
+						Region:      "West",
+						Country:     "US",
+						Continent:   "North America",
+						Description: "Silicon Valley, California",
+						Airport:     "SJC",
+					},
+				},
+				Subscription: ContainerRegistrySubscription{
+					Billing: ContainerRegistrySubscriptionBilling{
+						MonthlyPrice:   5,
+						PendingCharges: 0.01,
+					},
+				},
+			},
+		},
+	}
+
+	expectedMeta := &Meta{
+		Total: 2,
+		Links: &Links{
+			Next: "",
+			Prev: "",
+		},
+	}
+
+	if !reflect.DeepEqual(vcrs, expected) {
+		t.Errorf("ContainerRegistry.List returned %+v, expected %+v", vcrs, expected)
+	}
+
+	if !reflect.DeepEqual(meta, expectedMeta) {
+		t.Errorf("ContainerRegistry.List meta returned %+v, expected %+v", meta, expectedMeta)
+	}
+
+	c, can := context.WithTimeout(ctx, 1*time.Microsecond)
+	defer can()
+	if _, _, _, err = client.ContainerRegistry.List(c, nil); err == nil {
+		t.Error("ContainerRegistry.List returned nil")
+	}
+}
+
+func TestVCRServiceHandler_Get(t *testing.T) {
+	setup()
+	defer teardown()
+
+	vcrID := "e1d6be16-2b0c-4d76-a3eb-f28bf6ea5fe0"
+
+	mux.HandleFunc(fmt.Sprintf("%s/%s", vcrPath, vcrID), func(writer http.ResponseWriter, request *http.Request) {
+		response := `{
+    "id": "e1d6be16-2b0c-4d76-a3eb-f28bf6ea5fe0",
+    "name": "govultrtest",
+    "region": "sjc",
+    "urn": "sjc.vultrcr.com/govultrtest",
+    "storage": {
+        "used": {
+            "updated_at": "2023-11-09 13:37:12",
+            "bytes": 0,
+            "mb": 0,
+            "gb": 0,
+            "tb": 0
+        },
+        "allowed": {
+            "bytes": 21474836480,
+            "mb": 20480,
+            "gb": 20,
+            "tb": 0.02
+        }
+    },
+    "date_created": "2023-11-09 13:37:12",
+    "public": false,
+    "root_user": {
+        "id": 635,
+        "username": "e1d6be16-2b0c-4d76-a3eb-f28bf6ea5fe0",
+        "password": "5dEr33smkSYauMmRWusNFk9HpweL5CevpnFr",
+        "root": true,
+        "added_at": "2023-11-09 13:37:12",
+        "updated_at": "2023-11-09 13:37:12"
+    },
+    "metadata": {
+        "region": {
+            "id": 3,
+            "name": "sjc",
+            "urn": "sjc.vultrcr.com",
+            "base_url": "https://sjc.vultrcr.com",
+            "public": true,
+            "added_at": "2023-09-14 09:09:16",
+            "updated_at": "2023-09-14 09:09:16",
+            "data_center": {
+                "id": 12,
+                "name": "Silicon Valley",
+                "site_code": "SJC2",
+                "region": "West",
+                "country": "US",
+                "continent": "North America",
+                "description": "Silicon Valley, California",
+                "airport": "SJC"
+            }
+        },
+        "subscription": {
+            "billing": {
+                "monthly_price": 5,
+                "pending_charges": 0
+            }
+        }
+    }
+}`
+		fmt.Fprint(writer, response)
+	})
+
+	vcr, _, err := client.ContainerRegistry.Get(ctx, vcrID)
+	if err != nil {
+		t.Errorf("ContainerRegistry.Get returned %v", err)
+	}
+
+	expected := &ContainerRegistry{
+		ID:   "e1d6be16-2b0c-4d76-a3eb-f28bf6ea5fe0",
+		Name: "govultrtest",
+		URN:  "sjc.vultrcr.com/govultrtest",
+		Storage: ContainerRegistryStorage{
+			Used: ContainerRegistryStorageCount{
+				Bytes:        0,
+				MegaBytes:    0,
+				GigaBytes:    0,
+				TeraBytes:    0,
+				DateModified: "2023-11-09 13:37:12",
+			},
+			Allowed: ContainerRegistryStorageCount{
+				Bytes:        21474836480,
+				MegaBytes:    20480,
+				GigaBytes:    20,
+				TeraBytes:    0.02,
+				DateModified: "",
+			},
+		},
+		DateCreated: "2023-11-09 13:37:12",
+		Public:      false,
+		RootUser: ContainerRegistryUser{
+			ID:           635,
+			UserName:     "e1d6be16-2b0c-4d76-a3eb-f28bf6ea5fe0",
+			Password:     "5dEr33smkSYauMmRWusNFk9HpweL5CevpnFr",
+			Root:         true,
+			DateCreated:  "2023-11-09 13:37:12",
+			DateModified: "2023-11-09 13:37:12",
+		},
+		Metadata: ContainerRegistryMetadata{
+			Region: ContainerRegistryRegion{
+				ID:           3,
+				Name:         "sjc",
+				URN:          "sjc.vultrcr.com",
+				BaseURL:      "https://sjc.vultrcr.com",
+				Public:       true,
+				DateCreated:  "2023-09-14 09:09:16",
+				DateModified: "2023-09-14 09:09:16",
+				DataCenter: ContainerRegistryRegionDataCenter{
+					ID:          12,
+					Name:        "Silicon Valley",
+					SiteCode:    "SJC2",
+					Region:      "West",
+					Country:     "US",
+					Continent:   "North America",
+					Description: "Silicon Valley, California",
+					Airport:     "SJC",
+				},
+			},
+			Subscription: ContainerRegistrySubscription{
+				Billing: ContainerRegistrySubscriptionBilling{
+					MonthlyPrice:   5,
+					PendingCharges: 0,
+				},
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(vcr, expected) {
+		t.Errorf("ContainerRegistry.Get returned %+v, expected %+v", vcr, expected)
+	}
+
+	c, can := context.WithTimeout(ctx, 1*time.Microsecond)
+	defer can()
+	_, _, err = client.ContainerRegistry.Get(c, vcrID)
+	if err == nil {
+		t.Error("ContainerRegistry.Get returned nil")
+	}
+}
+
+func TestVCRServiceHandler_Update(t *testing.T) {
+	setup()
+	defer teardown()
+
+	vcrID := "e1d6be16-2b0c-4d76-a3eb-f28bf6ea5fe0"
+
+	mux.HandleFunc(fmt.Sprintf("%s/%s", vcrPath, vcrID), func(writer http.ResponseWriter, request *http.Request) {
+		response := `{
+    "id": "e1d6be16-2b0c-4d76-a3eb-f28bf6ea5fe0",
+    "name": "govultrtest",
+    "region": "sjc",
+    "urn": "sjc.vultrcr.com/govultrtest",
+    "storage": {
+        "used": {
+            "updated_at": "2023-11-09 13:37:12",
+            "bytes": 0,
+            "mb": 0,
+            "gb": 0,
+            "tb": 0
+        },
+        "allowed": {
+            "bytes": 21474836480,
+            "mb": 20480,
+            "gb": 20,
+            "tb": 0.02
+        }
+    },
+    "date_created": "2023-11-09 13:37:12",
+    "public": false,
+    "root_user": {
+        "id": 635,
+        "username": "e1d6be16-2b0c-4d76-a3eb-f28bf6ea5fe0",
+        "password": "5dEr33smkSYauMmRWusNFk9HpweL5CevpnFr",
+        "root": true,
+        "added_at": "2023-11-09 13:37:12",
+        "updated_at": "2023-11-09 13:37:12"
+    },
+    "metadata": {
+        "region": {
+            "id": 3,
+            "name": "sjc",
+            "urn": "sjc.vultrcr.com",
+            "base_url": "https://sjc.vultrcr.com",
+            "public": true,
+            "added_at": "2023-09-14 09:09:16",
+            "updated_at": "2023-09-14 09:09:16",
+            "data_center": {
+                "id": 12,
+                "name": "Silicon Valley",
+                "site_code": "SJC2",
+                "region": "West",
+                "country": "US",
+                "continent": "North America",
+                "description": "Silicon Valley, California",
+                "airport": "SJC"
+            }
+        },
+        "subscription": {
+            "billing": {
+                "monthly_price": 5,
+                "pending_charges": 0
+            }
+        }
+    }
+}`
+		fmt.Fprint(writer, response)
+	})
+
+	req := &ContainerRegistryUpdateReq{
+		Public: BoolToBoolPtr(true),
+	}
+
+	vcr, _, err := client.ContainerRegistry.Update(ctx, vcrID, req)
+	if err != nil {
+		t.Errorf("ContainerRegistry.Update returned %v", err)
+	}
+
+	expected := &ContainerRegistry{
+		ID:   "e1d6be16-2b0c-4d76-a3eb-f28bf6ea5fe0",
+		Name: "govultrtest",
+		URN:  "sjc.vultrcr.com/govultrtest",
+		Storage: ContainerRegistryStorage{
+			Used: ContainerRegistryStorageCount{
+				Bytes:        0,
+				MegaBytes:    0,
+				GigaBytes:    0,
+				TeraBytes:    0,
+				DateModified: "2023-11-09 13:37:12",
+			},
+			Allowed: ContainerRegistryStorageCount{
+				Bytes:        21474836480,
+				MegaBytes:    20480,
+				GigaBytes:    20,
+				TeraBytes:    0.02,
+				DateModified: "",
+			},
+		},
+		DateCreated: "2023-11-09 13:37:12",
+		Public:      false,
+		RootUser: ContainerRegistryUser{
+			ID:           635,
+			UserName:     "e1d6be16-2b0c-4d76-a3eb-f28bf6ea5fe0",
+			Password:     "5dEr33smkSYauMmRWusNFk9HpweL5CevpnFr",
+			Root:         true,
+			DateCreated:  "2023-11-09 13:37:12",
+			DateModified: "2023-11-09 13:37:12",
+		},
+		Metadata: ContainerRegistryMetadata{
+			Region: ContainerRegistryRegion{
+				ID:           3,
+				Name:         "sjc",
+				URN:          "sjc.vultrcr.com",
+				BaseURL:      "https://sjc.vultrcr.com",
+				Public:       true,
+				DateCreated:  "2023-09-14 09:09:16",
+				DateModified: "2023-09-14 09:09:16",
+				DataCenter: ContainerRegistryRegionDataCenter{
+					ID:          12,
+					Name:        "Silicon Valley",
+					SiteCode:    "SJC2",
+					Region:      "West",
+					Country:     "US",
+					Continent:   "North America",
+					Description: "Silicon Valley, California",
+					Airport:     "SJC",
+				},
+			},
+			Subscription: ContainerRegistrySubscription{
+				Billing: ContainerRegistrySubscriptionBilling{
+					MonthlyPrice:   5,
+					PendingCharges: 0,
+				},
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(vcr, expected) {
+		t.Errorf("ContainerRegistry.Update returned %+v \n\n expected %+v", vcr, expected)
+	}
+
+	c, can := context.WithTimeout(ctx, 1*time.Microsecond)
+	defer can()
+	_, _, err = client.ContainerRegistry.Update(c, vcrID, req)
+	if err == nil {
+		t.Error("ContainerRegistry.Update returned nil")
+	}
+}
+
+func TestVCRServiceHandler_Delete(t *testing.T) {
+	setup()
+	defer teardown()
+
+	vcrID := "e1d6be16-2b0c-4d76-a3eb-f28bf6ea5fe0"
+
+	mux.HandleFunc(fmt.Sprintf("%s/%s", vcrPath, vcrID), func(writer http.ResponseWriter, request *http.Request) {
+		fmt.Fprint(writer)
+	})
+
+	err := client.ContainerRegistry.Delete(ctx, vcrID)
+	if err != nil {
+		t.Errorf("ContainerRegistry.Delete returned %+v", err)
+	}
+}
+
+func TestVCRServiceHandler_GetRepository(t *testing.T) {
+	setup()
+	defer teardown()
+
+	vcrID := "e1d6be16-2b0c-4d76-a3eb-f28bf6ea5fe0"
+	vcrImage := "vultr-csi"
+
+	mux.HandleFunc(fmt.Sprintf("%s/%s/repository/%s", vcrPath, vcrID, vcrImage), func(writer http.ResponseWriter, request *http.Request) {
+		response := `{
+    "name": "govultrtest/vultr-csi",
+    "image": "vultr-csi",
+    "description": "",
+    "added_at": "2023-10-05T18:22:17.041Z",
+    "updated_at": "2023-10-27T23:26:09.369Z",
+    "pull_count": 9,
+    "artifact_count": 7
+}`
+		fmt.Fprint(writer, response)
+	})
+
+	vcrRepo, _, err := client.ContainerRegistry.GetRepository(ctx, vcrID, vcrImage)
+	if err != nil {
+		t.Errorf("ContainerRegistry.GetRepository returned %+v", err)
+	}
+
+	expected := &ContainerRegistryRepo{
+		Name:          "govultrtest/vultr-csi",
+		Image:         "vultr-csi",
+		Description:   "",
+		DateCreated:   "2023-10-05T18:22:17.041Z",
+		DateModified:  "2023-10-27T23:26:09.369Z",
+		PullCount:     9,
+		ArtifactCount: 7,
+	}
+
+	if !reflect.DeepEqual(vcrRepo, expected) {
+		t.Errorf("ContainerRegistry.GetRepository returned %+v, expected %+v", vcrRepo, expected)
+	}
+
+	c, can := context.WithTimeout(ctx, 1*time.Microsecond)
+	defer can()
+	if _, _, err = client.ContainerRegistry.GetRepository(c, vcrID, vcrImage); err == nil {
+		t.Error("ContainerRegistry.GetRepository returned nil")
+	}
+}
+
+func TestVCRServiceHandler_ListRepositories(t *testing.T) {
+	setup()
+	defer teardown()
+
+	vcrID := "e1d6be16-2b0c-4d76-a3eb-f28bf6ea5fe0"
+
+	mux.HandleFunc(fmt.Sprintf("%s/%s/repositories", vcrPath, vcrID), func(writer http.ResponseWriter, request *http.Request) {
+		response := `{
+    "repositories": [
+        {
+            "name": "govultrtest/vultr-csi",
+            "image": "vultr-csi",
+            "description": "",
+            "added_at": "2023-10-05T18:22:17.041Z",
+            "updated_at": "2023-10-27T23:26:09.369Z",
+            "pull_count": 9,
+            "artifact_count": 7
+        }
+    ],
+    "meta": {
+        "total": 1,
+        "links": {
+            "next": "",
+            "prev": ""
+        }
+    }
+}`
+		fmt.Fprint(writer, response)
+	})
+
+	vcrRepos, meta, _, err := client.ContainerRegistry.ListRepositories(ctx, vcrID, nil)
+	if err != nil {
+		t.Errorf("ContainerRegistry.ListRepositories returned %+v", err)
+	}
+
+	expected := []ContainerRegistryRepo{
+		{
+			Name:          "govultrtest/vultr-csi",
+			Image:         "vultr-csi",
+			Description:   "",
+			DateCreated:   "2023-10-05T18:22:17.041Z",
+			DateModified:  "2023-10-27T23:26:09.369Z",
+			PullCount:     9,
+			ArtifactCount: 7,
+		},
+	}
+
+	expectedMeta := &Meta{
+		Total: 1,
+		Links: &Links{
+			Next: "",
+			Prev: "",
+		},
+	}
+
+	if !reflect.DeepEqual(vcrRepos, expected) {
+		t.Errorf("ContainerRegistry.ListRepositories returned %+v, expected %+v", vcrRepos, expected)
+	}
+
+	if !reflect.DeepEqual(meta, expectedMeta) {
+		t.Errorf("ContainerRegistry.ListRepositories meta returned %+v, expected %+v", meta, expectedMeta)
+	}
+
+	c, can := context.WithTimeout(ctx, 1*time.Microsecond)
+	defer can()
+	if _, _, _, err = client.ContainerRegistry.ListRepositories(c, vcrID, nil); err == nil {
+		t.Error("ContainerRegistry.ListRepositories returned nil")
+	}
+}
+
+func TestVCRServiceHandler_UpdateRepository(t *testing.T) {
+	setup()
+	defer teardown()
+
+	vcrID := "e1d6be16-2b0c-4d76-a3eb-f28bf6ea5fe0"
+	vcrImage := "vultr-csi"
+
+	mux.HandleFunc(fmt.Sprintf("%s/%s/repository/%s", vcrPath, vcrID, vcrImage), func(writer http.ResponseWriter, request *http.Request) {
+		response := `{
+    "name": "govultrtest/vultr-csi",
+    "image": "vultr-csi",
+    "description": "test",
+    "added_at": "2023-10-05T18:22:17.041Z",
+    "updated_at": "2023-10-27T23:26:09.369Z",
+    "pull_count": 9,
+    "artifact_count": 7
+}`
+		fmt.Fprint(writer, response)
+	})
+
+	req := &ContainerRegistryRepoUpdateReq{
+		Description: "test",
+	}
+
+	vcrRepo, _, err := client.ContainerRegistry.UpdateRepository(ctx, vcrID, vcrImage, req)
+	if err != nil {
+		t.Errorf("ContainerRegistry.UpdateRepository returned %+v", err)
+	}
+
+	expected := &ContainerRegistryRepo{
+		Name:          "govultrtest/vultr-csi",
+		Image:         "vultr-csi",
+		Description:   "test",
+		DateCreated:   "2023-10-05T18:22:17.041Z",
+		DateModified:  "2023-10-27T23:26:09.369Z",
+		PullCount:     9,
+		ArtifactCount: 7,
+	}
+
+	if !reflect.DeepEqual(vcrRepo, expected) {
+		t.Errorf("ContainerRegistry.UpdateRepository returned %+v, expected %+v", vcrRepo, expected)
+	}
+
+	c, can := context.WithTimeout(ctx, 1*time.Microsecond)
+	defer can()
+	if _, _, err = client.ContainerRegistry.UpdateRepository(c, vcrID, vcrImage, req); err == nil {
+		t.Error("ContainerRegistry.UpdateRepository returned nil")
+	}
+}
+
+func TestVCRServiceHandler_DeleteRepository(t *testing.T) {
+	setup()
+	defer teardown()
+
+	vcrID := "e1d6be16-2b0c-4d76-a3eb-f28bf6ea5fe0"
+	vcrImage := "vultr-csi"
+
+	mux.HandleFunc(fmt.Sprintf("%s/%s/repository/%s", vcrPath, vcrID, vcrImage), func(writer http.ResponseWriter, request *http.Request) {
+		fmt.Fprint(writer)
+	})
+
+	err := client.ContainerRegistry.DeleteRepository(ctx, vcrID, vcrImage)
+	if err != nil {
+		t.Errorf("ContainerRegistry.DeleteRepository returned %+v", err)
+	}
+}
+
+func TestVCRServiceHandler_ListRegions(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc(fmt.Sprintf("%s/region/list", vcrPath), func(writer http.ResponseWriter, request *http.Request) {
+		response := `{
+    "regions": [
+        {
+            "id": 3,
+            "name": "sjc",
+            "urn": "sjc.vultrcr.com",
+            "base_url": "https://sjc.vultrcr.com",
+            "public": true,
+            "added_at": "2023-09-14 09:09:16",
+            "updated_at": "2023-09-14 09:09:16",
+            "data_center": {
+                "id": 12,
+                "name": "Silicon Valley",
+                "site_code": "SJC2",
+                "region": "West",
+                "country": "US",
+                "continent": "North America",
+                "description": "Silicon Valley, California",
+                "airport": "SJC"
+            }
+        }
+    ],
+    "meta": {
+        "total": 1,
+        "links": {
+            "next": "",
+            "prev": ""
+        }
+    }
+}`
+		fmt.Fprint(writer, response)
+	})
+
+	vcrRegions, meta, _, err := client.ContainerRegistry.ListRegions(ctx, nil)
+	if err != nil {
+		t.Errorf("ContainerRegistry.ListRegions returned %v", err)
+	}
+
+	expected := []ContainerRegistryRegion{
+		{
+			ID:           3,
+			Name:         "sjc",
+			URN:          "sjc.vultrcr.com",
+			BaseURL:      "https://sjc.vultrcr.com",
+			Public:       true,
+			DateCreated:  "2023-09-14 09:09:16",
+			DateModified: "2023-09-14 09:09:16",
+			DataCenter: ContainerRegistryRegionDataCenter{
+				ID:          12,
+				Name:        "Silicon Valley",
+				SiteCode:    "SJC2",
+				Region:      "West",
+				Country:     "US",
+				Continent:   "North America",
+				Description: "Silicon Valley, California",
+				Airport:     "SJC",
+			},
+		},
+	}
+
+	expectedMeta := &Meta{
+		Total: 1,
+		Links: &Links{
+			Next: "",
+			Prev: "",
+		},
+	}
+
+	if !reflect.DeepEqual(vcrRegions, expected) {
+		t.Errorf("ContainerRegistry.ListRegions returned %+v, expected %+v", vcrRegions, expected)
+	}
+
+	if !reflect.DeepEqual(meta, expectedMeta) {
+		t.Errorf("ContainerRegistry.ListRegions meta returned %+v, expected %+v", meta, expectedMeta)
+	}
+
+	c, can := context.WithTimeout(ctx, 1*time.Microsecond)
+	defer can()
+	_, _, _, err = client.ContainerRegistry.ListRegions(c, nil)
+	if err == nil {
+		t.Error("ContainerRegistry.ListRegions returned nil")
+	}
+}
+
+func TestVCRServiceHandler_ListPlans(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc(fmt.Sprintf("%s/plan/list", vcrPath), func(writer http.ResponseWriter, request *http.Request) {
+		response := `{
+    "plans": {
+        "start_up": {
+            "vanity_name": "Start Up",
+            "max_storage_mb": 10240,
+            "monthly_price": 0
+        },
+        "business": {
+            "vanity_name": "Business",
+            "max_storage_mb": 20480,
+            "monthly_price": 5
+        },
+        "premium": {
+            "vanity_name": "Premium",
+            "max_storage_mb": 51200,
+            "monthly_price": 10
+        },
+        "enterprise": {
+            "vanity_name": "Enterprise",
+            "max_storage_mb": 1048576,
+            "monthly_price": 20
+        }
+    }
+}`
+		fmt.Fprint(writer, response)
+	})
+
+	vcrPlans, _, err := client.ContainerRegistry.ListPlans(ctx)
+	if err != nil {
+		t.Errorf("ContainerRegistry.ListPlans returned %v", err)
+	}
+
+	expected := &ContainerRegistryPlans{
+		Plans: ContainerRegistryPlanTypes{
+			StartUp: ContainerRegistryPlan{
+				VanityName:   "Start Up",
+				MaxStorageMB: 10240,
+				MonthlyPrice: 0,
+			},
+			Business: ContainerRegistryPlan{
+				VanityName:   "Business",
+				MaxStorageMB: 20480,
+				MonthlyPrice: 5,
+			},
+			Premium: ContainerRegistryPlan{
+				VanityName:   "Premium",
+				MaxStorageMB: 51200,
+				MonthlyPrice: 10,
+			},
+			Enterprise: ContainerRegistryPlan{
+				VanityName:   "Enterprise",
+				MaxStorageMB: 1048576,
+				MonthlyPrice: 20,
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(vcrPlans, expected) {
+		t.Errorf("ContainerRegistry.ListPlans returned %+v, expected %+v", vcrPlans, expected)
+	}
+
+	c, can := context.WithTimeout(ctx, 1*time.Microsecond)
+	defer can()
+	_, _, err = client.ContainerRegistry.ListPlans(c)
+	if err == nil {
+		t.Error("ContainerRegistry.ListPlans returned nil")
+	}
+}

--- a/govultr.go
+++ b/govultr.go
@@ -1,3 +1,5 @@
+// Package govultr contains the functionality to interact with the Vultr public
+// HTTP REST API.
 package govultr
 
 import (

--- a/govultr.go
+++ b/govultr.go
@@ -180,14 +180,14 @@ func (c *Client) DoWithContext(ctx context.Context, r *http.Request, data interf
 
 	rreq = rreq.WithContext(ctx)
 
-	res, err := c.client.Do(rreq)
+	res, errDo := c.client.Do(rreq)
 
 	if c.onRequestCompleted != nil {
 		c.onRequestCompleted(r, res)
 	}
 
-	if err != nil {
-		return nil, err
+	if errDo != nil {
+		return nil, errDo
 	}
 
 	defer func() {

--- a/govultr.go
+++ b/govultr.go
@@ -39,21 +39,22 @@ type Client struct {
 	UserAgent string
 
 	// Services used to interact with the API
-	Account         AccountService
-	Application     ApplicationService
-	Backup          BackupService
-	BareMetalServer BareMetalServerService
-	Billing         BillingService
-	BlockStorage    BlockStorageService
-	Database        DatabaseService
-	Domain          DomainService
-	DomainRecord    DomainRecordService
-	FirewallGroup   FirewallGroupService
-	FirewallRule    FireWallRuleService
-	Instance        InstanceService
-	ISO             ISOService
-	Kubernetes      KubernetesService
-	LoadBalancer    LoadBalancerService
+	Account           AccountService
+	Application       ApplicationService
+	Backup            BackupService
+	BareMetalServer   BareMetalServerService
+	Billing           BillingService
+	BlockStorage      BlockStorageService
+	ContainerRegistry ContainerRegistryService
+	Database          DatabaseService
+	Domain            DomainService
+	DomainRecord      DomainRecordService
+	FirewallGroup     FirewallGroupService
+	FirewallRule      FireWallRuleService
+	Instance          InstanceService
+	ISO               ISOService
+	Kubernetes        KubernetesService
+	LoadBalancer      LoadBalancerService
 	// Deprecated: Network should no longer be used. Instead, use VPC.
 	Network       NetworkService
 	ObjectStorage ObjectStorageService
@@ -116,6 +117,7 @@ func NewClient(httpClient *http.Client) *Client {
 	client.BareMetalServer = &BareMetalServerServiceHandler{client}
 	client.Billing = &BillingServiceHandler{client}
 	client.BlockStorage = &BlockStorageServiceHandler{client}
+	client.ContainerRegistry = &ContainerRegistryServiceHandler{client}
 	client.Database = &DatabaseServiceHandler{client}
 	client.Domain = &DomainServiceHandler{client}
 	client.DomainRecord = &DomainRecordsServiceHandler{client}

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -256,7 +256,7 @@ func (k *KubernetesHandler) CreateNodePool(ctx context.Context, vkeID string, no
 }
 
 // ListNodePools will return all nodepools for a given VKE cluster
-func (k *KubernetesHandler) ListNodePools(ctx context.Context, vkeID string, options *ListOptions) ([]NodePool, *Meta, *http.Response, error) { //nolint:lll
+func (k *KubernetesHandler) ListNodePools(ctx context.Context, vkeID string, options *ListOptions) ([]NodePool, *Meta, *http.Response, error) { //nolint:lll,dupl
 	req, err := k.client.NewRequest(ctx, http.MethodGet, fmt.Sprintf("%s/%s/node-pools", vkePath, vkeID), nil)
 	if err != nil {
 		return nil, nil, nil, err

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -308,7 +308,7 @@ func TestKubernetesHandler_ListClusters(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(meta, expectedMeta) {
-		t.Errorf("Kubernetes.List meta returned %+v, expected %+v", vke, expected)
+		t.Errorf("Kubernetes.List meta returned %+v, expected %+v", meta, expectedMeta)
 	}
 
 	c, can := context.WithTimeout(ctx, 1*time.Microsecond)

--- a/object_storage.go
+++ b/object_storage.go
@@ -21,7 +21,7 @@ type ObjectStorageService interface {
 	RegenerateKeys(ctx context.Context, id string) (*S3Keys, *http.Response, error)
 }
 
-// ObjectStorageServiceHandler handles interaction with the firewall rule methods for the Vultr API.
+// ObjectStorageServiceHandler handles interaction between the object storage service and the Vultr API.
 type ObjectStorageServiceHandler struct {
 	client *Client
 }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
* Add in support for all VCR operations except for the Kubernetes credentials (API changes required to make that operation work or #279 might suffice)


## Testing Instructions
Check that the functions return data from the API:
```golang
func main() {
	vultrClient, ctx := getClient()

	// VCR -- comment/un-comment each to test
	vcrGet(ctx, vultrClient)
	vcrList(ctx, vultrClient)
	vcrCreate(ctx, vultrClient)
	vcrUpdate(ctx, vultrClient)
	vcrDelete(ctx, vultrClient)
	vcrListRepos(ctx, vultrClient)
	vcrGetRepo(ctx, vultrClient)
	vcrDeleteRepo(ctx, vultrClient)
	vcrCreateDockerCredentials(ctx, vultrClient)
	vcrListRegions(ctx, vultrClient)
	vcrListPlans(ctx, vultrClient)
}

func getClient() (*govultr.Client, context.Context) {
	apiKey := "YOUR API KEY"
	config := &oauth2.Config{}
	ctx := context.Background()
	ts := config.TokenSource(ctx, &oauth2.Token{AccessToken: apiKey})
	vultrClient := govultr.NewClient(oauth2.NewClient(ctx, ts))
	return vultrClient, ctx
}

func printJson(output interface{}) {

	json, err := json.MarshalIndent(output, "", "\t")

	if err != nil {
		fmt.Println(err)
		panic(err.Error())
	}

	fmt.Printf("%s", string(json))
}

func vcrGet(ctx context.Context, client *govultr.Client) {
	vcrID := "YOUR VCR ID"

	vcr, _, err := client.ContainerRegistry.Get(ctx, vcrID)
	if err != nil {
		fmt.Println(err)
		panic(err.Error())
	}

	printJson(vcr)
}

func vcrList(ctx context.Context, client *govultr.Client) {
	vcrs, _, _, err := client.ContainerRegistry.List(ctx, nil)
	if err != nil {
		fmt.Println(err)
		panic(err.Error())
	}

	printJson(vcrs)
}

func vcrListRegions(ctx context.Context, client *govultr.Client) {
	vcrRegions, _, _, err := client.ContainerRegistry.ListRegions(ctx, nil)
	if err != nil {
		fmt.Println(err)
		panic(err.Error())
	}

	printJson(vcrRegions)
}

func vcrListPlans(ctx context.Context, client *govultr.Client) {
	vcrPlans, _, err := client.ContainerRegistry.ListPlans(ctx)
	if err != nil {
		fmt.Println(err)
		panic(err.Error())
	}

	printJson(vcrPlans)
}

func vcrCreate(ctx context.Context, client *govultr.Client) {
	vcr, _, err := client.ContainerRegistry.Create(ctx, &govultr.ContainerRegistryReq{
		Name:   "govultrtest",
		Region: "sjc",
		Public: true,
		Plan:   "business",
	})
	if err != nil {
		fmt.Println(err)
		panic(err.Error())
	}

	printJson(vcr)
}

func vcrUpdate(ctx context.Context, client *govultr.Client) {
	vcrID := "YOUR VCR ID"

	vcr, _, err := client.ContainerRegistry.Update(ctx, vcrID, &govultr.ContainerRegistryReqUpdate{
		Public: govultr.BoolToBoolPtr(true),
		Plan:   govultr.StringToStringPtr("business"),
	})
	if err != nil {
		fmt.Println(err)
		panic(err.Error())
	}

	printJson(vcr)
}

func vcrDelete(ctx context.Context, client *govultr.Client) {
	vcrID := "YOUR VCR ID"

	if err := client.ContainerRegistry.Delete(ctx, vcrID); err != nil {
		fmt.Println(err)
		panic(err.Error())
	}
}

func vcrListRepos(ctx context.Context, client *govultr.Client) {
	vcrID := "YOUR VCR ID"

	vcrRepos, _, _, err := client.ContainerRegistry.ListRepositories(ctx, vcrID, nil)
	if err != nil {
		fmt.Println(err)
		panic(err.Error())
	}

	printJson(vcrRepos)
}

func vcrGetRepo(ctx context.Context, client *govultr.Client) {
	vcrID := "YOUR VCR ID"
	repoName := "vultr-csi"

	vcrRepo, _, err := client.ContainerRegistry.GetRepository(ctx, vcrID, repoName)
	if err != nil {
		fmt.Println(err)
		panic(err.Error())
	}

	printJson(vcrRepo)
}

func vcrCreateDockerCredentials(ctx context.Context, client *govultr.Client) {
	vcrID := "YOUR VCR ID"

	vcrCred, _, err := client.ContainerRegistry.CreateDockerCredentials(ctx, vcrID, &govultr.DockerCredentialsOpt{
		ExpirySeconds: govultr.IntToIntPtr(0),
		WriteAccess:   govultr.BoolToBoolPtr(false),
	})

	if err != nil {
		fmt.Println(err)
		panic(err.Error())
	}

	fmt.Print(vcrCred)
}
```
The tests:
```
go test -v -run TestVCRServiceHandler_                                                                                             20:37
=== RUN   TestVCRServiceHandler_Create
--- PASS: TestVCRServiceHandler_Create (0.00s)
=== RUN   TestVCRServiceHandler_List
--- PASS: TestVCRServiceHandler_List (0.00s)
=== RUN   TestVCRServiceHandler_Get
--- PASS: TestVCRServiceHandler_Get (0.00s)
=== RUN   TestVCRServiceHandler_Update
--- PASS: TestVCRServiceHandler_Update (0.00s)
=== RUN   TestVCRServiceHandler_Delete
--- PASS: TestVCRServiceHandler_Delete (0.00s)
=== RUN   TestVCRServiceHandler_GetRepository
--- PASS: TestVCRServiceHandler_GetRepository (0.00s)
=== RUN   TestVCRServiceHandler_ListRepositories
--- PASS: TestVCRServiceHandler_ListRepositories (0.00s)
=== RUN   TestVCRServiceHandler_UpdateRepository
--- PASS: TestVCRServiceHandler_UpdateRepository (0.00s)
=== RUN   TestVCRServiceHandler_DeleteRepository
--- PASS: TestVCRServiceHandler_DeleteRepository (0.00s)
=== RUN   TestVCRServiceHandler_ListRegions
--- PASS: TestVCRServiceHandler_ListRegions (0.00s)
=== RUN   TestVCRServiceHandler_ListPlans
--- PASS: TestVCRServiceHandler_ListPlans (0.00s)
PASS
ok      github.com/vultr/govultr/v3     0.007s
```

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
