### PR TITLE
Allow empty values in startup script request struct

### DIFF
--- a/startup_script.go
+++ b/startup_script.go
@@ -37,9 +37,9 @@ type StartupScript struct {
 
 // StartupScriptReq is the user struct for create and update calls
 type StartupScriptReq struct {
-	Name   string `json:"name"`
-	Type   string `json:"type"`
-	Script string `json:"script"`
+	Name   string `json:"name,omitempty"`
+	Type   string `json:"type,omitempty"`
+	Script string `json:"script,omitempty"`
 }
 
 type startupScriptsBase struct {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
Adds the `omitempty` struct tag since it's the same struct used for update as is used for create.  As it is now, when updates are made, any empty values get sent to the API which will wipe the values.

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
#295 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [ ] Have you successfully ran tests with your changes locally?
