### PR TITLE
[Feature] add MdiskMode to BareMetalCreate and BareMetalUpdate structs

### DIFF
--- a/bare_metal_server.go
+++ b/bare_metal_server.go
@@ -95,6 +95,7 @@ type BareMetalCreate struct {
 	UserData        string   `json:"user_data,omitempty"`
 	ActivationEmail *bool    `json:"activation_email,omitempty"`
 	Hostname        string   `json:"hostname,omitempty"`
+	MdiskMode       string   `json:"mdisk_mode,omitempty"`
 	// Deprecated: Tag should no longer be used. Instead, use Tags.
 	Tag           string            `json:"tag,omitempty"`
 	ReservedIPv4  string            `json:"reserved_ipv4,omitempty"`
@@ -114,6 +115,7 @@ type BareMetalUpdate struct {
 	AppID      int    `json:"app_id,omitempty"`
 	ImageID    string `json:"image_id,omitempty"`
 	UserData   string `json:"user_data,omitempty"`
+	MdiskMode  string `json:"mdisk_mode,omitempty"`
 	// Deprecated: Tag should no longer be used. Instead, use Tags.
 	Tag        *string  `json:"tag,omitempty"`
 	Tags       []string `json:"tags"`


### PR DESCRIPTION
## Description
The mdisk_mode param for baremetal create and update was recently added to the [vultr api](https://www.vultr.com/api/#tag/baremetal/operation/create-baremetal). 

This pull request will add the mdisk_mode param as a possible input for the BareMetalCreate and BareMetalUpdate structs.

