### PR TITLE
Add support for virtual file system storages

### DIFF
--- a/govultr.go
+++ b/govultr.go
@@ -41,37 +41,38 @@ type Client struct {
 	UserAgent string
 
 	// Services used to interact with the API
-	Account           AccountService
-	Application       ApplicationService
-	Backup            BackupService
-	BareMetalServer   BareMetalServerService
-	Billing           BillingService
-	BlockStorage      BlockStorageService
-	CDN               CDNService
-	ContainerRegistry ContainerRegistryService
-	Database          DatabaseService
-	Domain            DomainService
-	DomainRecord      DomainRecordService
-	FirewallGroup     FirewallGroupService
-	FirewallRule      FireWallRuleService
-	Instance          InstanceService
-	ISO               ISOService
-	Kubernetes        KubernetesService
-	LoadBalancer      LoadBalancerService
-	Marketplace       MarketplaceService
-	ObjectStorage     ObjectStorageService
-	OS                OSService
-	Plan              PlanService
-	Region            RegionService
-	ReservedIP        ReservedIPService
-	Inference         InferenceService
-	Snapshot          SnapshotService
-	SSHKey            SSHKeyService
-	StartupScript     StartupScriptService
-	SubAccount        SubAccountService
-	User              UserService
-	VPC               VPCService
-	VPC2              VPC2Service
+	Account                  AccountService
+	Application              ApplicationService
+	Backup                   BackupService
+	BareMetalServer          BareMetalServerService
+	Billing                  BillingService
+	BlockStorage             BlockStorageService
+	CDN                      CDNService
+	ContainerRegistry        ContainerRegistryService
+	Database                 DatabaseService
+	Domain                   DomainService
+	DomainRecord             DomainRecordService
+	FirewallGroup            FirewallGroupService
+	FirewallRule             FireWallRuleService
+	Instance                 InstanceService
+	ISO                      ISOService
+	Kubernetes               KubernetesService
+	LoadBalancer             LoadBalancerService
+	Marketplace              MarketplaceService
+	ObjectStorage            ObjectStorageService
+	OS                       OSService
+	Plan                     PlanService
+	Region                   RegionService
+	ReservedIP               ReservedIPService
+	Inference                InferenceService
+	Snapshot                 SnapshotService
+	SSHKey                   SSHKeyService
+	StartupScript            StartupScriptService
+	SubAccount               SubAccountService
+	User                     UserService
+	VirtualFileSystemStorage VirtualFileSystemStorageService
+	VPC                      VPCService
+	VPC2                     VPC2Service
 
 	// Optional function called after every successful request made to the Vultr API
 	onRequestCompleted RequestCompletionCallback
@@ -144,6 +145,7 @@ func NewClient(httpClient *http.Client) *Client {
 	client.StartupScript = &StartupScriptServiceHandler{client}
 	client.SubAccount = &SubAccountServiceHandler{client}
 	client.User = &UserServiceHandler{client}
+	client.VirtualFileSystemStorage = &VirtualFileSystemStorageServiceHandler{client}
 	client.VPC = &VPCServiceHandler{client}
 	client.VPC2 = &VPC2ServiceHandler{client}
 

--- a/virtual_file_system_storage.go
+++ b/virtual_file_system_storage.go
@@ -195,8 +195,6 @@ func (f *VirtualFileSystemStorageServiceHandler) Attach(ctx context.Context, vfs
 		return nil, resp, err
 	}
 
-	fmt.Printf("%v", resp)
-
 	return att, resp, err
 }
 

--- a/virtual_file_system_storage.go
+++ b/virtual_file_system_storage.go
@@ -49,7 +49,7 @@ type VirtualFileSystemStorage struct {
 // VirtualFileSystemStorageSize represents the on disk size of a virtual file
 // system storage
 type VirtualFileSystemStorageSize struct {
-	SizeBytes int `json:"bytes"`
+	SizeBytes int `json:"bytes,omitempty"`
 	SizeGB    int `json:"gb"`
 }
 

--- a/virtual_file_system_storage.go
+++ b/virtual_file_system_storage.go
@@ -12,7 +12,7 @@ const virtualFileSystemStoragePath = "/v2/vfs"
 
 // VirtualFileSystemStorageService is the interface to interact with virtual
 // file system endpoint on the Vultr API
-// TODO: link // Link : https://www.vultr.com/api/#tag/block
+// Link : https://www.vultr.com/api/#tag/vfs
 type VirtualFileSystemStorageService interface {
 	Create(ctx context.Context, vfsReq *VirtualFileSystemStorageReq) (*VirtualFileSystemStorage, *http.Response, error)
 	Get(ctx context.Context, vfsID string) (*VirtualFileSystemStorage, *http.Response, error)
@@ -26,12 +26,12 @@ type VirtualFileSystemStorageService interface {
 }
 
 // VirtualFileSystemStorageServiceHandler handles interaction with the virtual
-// file system methods for the Vultr API
+// file system methods for the Vultr API.
 type VirtualFileSystemStorageServiceHandler struct {
 	client *Client
 }
 
-// VirtualFileSystemStorage represents a virtual file system storage
+// VirtualFileSystemStorage represents a virtual file system storage.
 type VirtualFileSystemStorage struct {
 	ID          string                          `json:"id"`
 	Region      string                          `json:"region"`
@@ -47,14 +47,14 @@ type VirtualFileSystemStorage struct {
 }
 
 // VirtualFileSystemStorageSize represents the on disk size of a virtual file
-// system storage
+// system storage.
 type VirtualFileSystemStorageSize struct {
 	SizeBytes int `json:"bytes,omitempty"`
 	SizeGB    int `json:"gb"`
 }
 
 // VirtualFileSystemStorageBilling represents the billing data of a virtual
-// file system storage
+// file system storage.
 type VirtualFileSystemStorageBilling struct {
 	Charges float32 `json:"charges"`
 	Monthly float32 `json:"monthly"`
@@ -83,7 +83,7 @@ type VirtualFileSystemStorageUpdateReq struct {
 }
 
 // VirtualFileSystemStorageAttachment represents an attachment for a virtual
-// file system
+// file system.
 type VirtualFileSystemStorageAttachment struct {
 	ID       string `json:"vfs_id"`
 	State    string `json:"state"`
@@ -197,7 +197,7 @@ func (f *VirtualFileSystemStorageServiceHandler) Attach(ctx context.Context, vfs
 }
 
 // AttachmentGet retrieves the attachment of a virtual file system storage and
-// the attached instance.
+// its attached instance.
 func (f *VirtualFileSystemStorageServiceHandler) AttachmentGet(ctx context.Context, vfsID, targetID string) (*VirtualFileSystemStorageAttachment, *http.Response, error) { //nolint:lll
 	uri := fmt.Sprintf("%s/%s/attachments/%s", virtualFileSystemStoragePath, vfsID, targetID)
 
@@ -216,7 +216,7 @@ func (f *VirtualFileSystemStorageServiceHandler) AttachmentGet(ctx context.Conte
 }
 
 // Detach sends a delete request for an attachment of a virtual file system
-// storage and another instance.
+// storage, detaching it from its instance.
 func (f *VirtualFileSystemStorageServiceHandler) Detach(ctx context.Context, vfsID, targetID string) error {
 	uri := fmt.Sprintf("%s/%s/attachments/%s", virtualFileSystemStoragePath, vfsID, targetID)
 

--- a/virtual_file_system_storage.go
+++ b/virtual_file_system_storage.go
@@ -88,6 +88,7 @@ type VirtualFileSystemStorageAttachment struct {
 	ID       string `json:"vfs_id"`
 	State    string `json:"state"`
 	TargetID string `json:"target_id"`
+	MountTag int    `json:"mount_tag"`
 }
 
 type virtualFileSystemStorageAttachmentsBase struct {

--- a/virtual_file_system_storage.go
+++ b/virtual_file_system_storage.go
@@ -38,7 +38,6 @@ type VirtualFileSystemStorage struct {
 	Region      string                          `json:"region"`
 	DateCreated string                          `json:"date_created"`
 	Status      string                          `json:"status"`
-	SubStatus   string                          `json:"sub_status"`
 	Label       string                          `json:"label"`
 	Tags        []string                        `json:"tags"`
 	DiskType    string                          `json:"disk_type"`

--- a/virtual_file_system_storage.go
+++ b/virtual_file_system_storage.go
@@ -71,8 +71,8 @@ type VirtualFileSystemStorageReq struct {
 	Region      string                       `json:"region"`
 	Label       string                       `json:"label"`
 	StorageSize VirtualFileSystemStorageSize `json:"storage_size"`
-	DiskType    string                       `json:"disk_type"`
-	Tags        []string                     `json:"tags"`
+	DiskType    string                       `json:"disk_type,omitempty"`
+	Tags        []string                     `json:"tags,omitempty"`
 }
 
 // VirtualFileSystemStorageUpdateReq struct represents the request used when

--- a/virtual_file_system_storage.go
+++ b/virtual_file_system_storage.go
@@ -1,0 +1,233 @@
+package govultr
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/google/go-querystring/query"
+)
+
+const virtualFileSystemStoragePath = "/v2/vfs"
+
+// VirtualFileSystemStorageService is the interface to interact with virtual
+// file system endpoint on the Vultr API
+// TODO: link // Link : https://www.vultr.com/api/#tag/block
+type VirtualFileSystemStorageService interface {
+	Create(ctx context.Context, vfsReq *VirtualFileSystemStorageReq) (*VirtualFileSystemStorage, *http.Response, error)
+	Get(ctx context.Context, vfsID string) (*VirtualFileSystemStorage, *http.Response, error)
+	Update(ctx context.Context, vfsID string, vfsUpdateReq *VirtualFileSystemStorageUpdateReq) (*VirtualFileSystemStorage, *http.Response, error) //nolint:lll
+	Delete(ctx context.Context, vfsID string) error
+	List(ctx context.Context, options *ListOptions) ([]VirtualFileSystemStorage, *Meta, *http.Response, error)
+
+	Attach(ctx context.Context, vfsID, targetID string) (*VirtualFileSystemStorageAttachment, *http.Response, error)
+	AttachmentGet(ctx context.Context, vfsID, targetID string) (*VirtualFileSystemStorageAttachment, *http.Response, error)
+	Detach(ctx context.Context, vfsID, targetID string) error
+}
+
+// VirtualFileSystemStorageServiceHandler handles interaction with the virtual
+// file system methods for the Vultr API
+type VirtualFileSystemStorageServiceHandler struct {
+	client *Client
+}
+
+// VirtualFileSystemStorage represents a virtual file system storage
+type VirtualFileSystemStorage struct {
+	ID          string                          `json:"id"`
+	Region      string                          `json:"region"`
+	DateCreated string                          `json:"date_created"`
+	Status      string                          `json:"status"`
+	SubStatus   string                          `json:"sub_status"`
+	Label       string                          `json:"label"`
+	Tags        []string                        `json:"tags"`
+	DiskType    string                          `json:"disk_type"`
+	StorageSize VirtualFileSystemStorageSize    `json:"storage_size"`
+	StorageUsed VirtualFileSystemStorageSize    `json:"storage_used"`
+	Billing     VirtualFileSystemStorageBilling `json:"billing"`
+}
+
+// VirtualFileSystemStorageSize represents the on disk size of a virtual file
+// system storage
+type VirtualFileSystemStorageSize struct {
+	SizeBytes int `json:"bytes"`
+	SizeGB    int `json:"gb"`
+}
+
+// VirtualFileSystemStorageBilling represents the billing data of a virtual
+// file system storage
+type VirtualFileSystemStorageBilling struct {
+	Charges float32 `json:"charges"`
+	Monthly float32 `json:"monthly"`
+}
+
+type virtualFileSystemStoragesBase struct {
+	VFSs []VirtualFileSystemStorage `json:"vfs"`
+	Meta *Meta                      `json:"meta"`
+}
+
+// VirtualFileSystemStorageReq struct represents the request used when creating
+// a virtual file system storage.
+type VirtualFileSystemStorageReq struct {
+	Region      string                       `json:"region"`
+	Label       string                       `json:"label"`
+	StorageSize VirtualFileSystemStorageSize `json:"storage_size"`
+	DiskType    string                       `json:"disk_type"`
+	Tags        []string                     `json:"tags"`
+}
+
+// VirtualFileSystemStorageUpdateReq struct represents the request used when
+// updating virtual file system storage.
+type VirtualFileSystemStorageUpdateReq struct {
+	Label       string                       `json:"label,omitempty"`
+	StorageSize VirtualFileSystemStorageSize `json:"storage_size"`
+}
+
+// VirtualFileSystemStorageAttachment represents an attachment for a virtual
+// file system
+type VirtualFileSystemStorageAttachment struct {
+	ID       string `json:"vfs_id"`
+	State    string `json:"state"`
+	TargetID string `json:"target_id"`
+}
+
+// Create sends a create request for a virtual file system storage.
+func (f *VirtualFileSystemStorageServiceHandler) Create(ctx context.Context, vfsReq *VirtualFileSystemStorageReq) (*VirtualFileSystemStorage, *http.Response, error) { //nolint:lll
+	req, err := f.client.NewRequest(ctx, http.MethodPost, virtualFileSystemStoragePath, vfsReq)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	vfs := new(VirtualFileSystemStorage)
+	resp, err := f.client.DoWithContext(ctx, req, vfs)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return vfs, resp, nil
+}
+
+// Get retrieves a single virtual file system storage.
+func (f *VirtualFileSystemStorageServiceHandler) Get(ctx context.Context, vfsID string) (*VirtualFileSystemStorage, *http.Response, error) {
+	uri := fmt.Sprintf("%s/%s", virtualFileSystemStoragePath, vfsID)
+
+	req, err := f.client.NewRequest(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	vfs := new(VirtualFileSystemStorage)
+	resp, err := f.client.DoWithContext(ctx, req, vfs)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return vfs, resp, nil
+}
+
+// Update sends a update request for a virtual file system storage.
+func (f *VirtualFileSystemStorageServiceHandler) Update(ctx context.Context, vfsID string, vfsUpdateReq *VirtualFileSystemStorageUpdateReq) (*VirtualFileSystemStorage, *http.Response, error) { //nolint:lll
+	uri := fmt.Sprintf("%s/%s", virtualFileSystemStoragePath, vfsID)
+
+	req, err := f.client.NewRequest(ctx, http.MethodPut, uri, vfsUpdateReq)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	vfs := new(VirtualFileSystemStorage)
+	resp, err := f.client.DoWithContext(ctx, req, vfs)
+	if err != nil {
+		return nil, resp, err
+	}
+	return vfs, resp, err
+}
+
+// Delete sends a delete request for a virtual file system storage.
+func (f *VirtualFileSystemStorageServiceHandler) Delete(ctx context.Context, vfsID string) error {
+	uri := fmt.Sprintf("%s/%s", virtualFileSystemStoragePath, vfsID)
+
+	req, err := f.client.NewRequest(ctx, http.MethodDelete, uri, nil)
+	if err != nil {
+		return err
+	}
+	_, err = f.client.DoWithContext(ctx, req, nil)
+	return err
+}
+
+// List retrieves a list of all virtual file system storages.
+func (f *VirtualFileSystemStorageServiceHandler) List(ctx context.Context, options *ListOptions) ([]VirtualFileSystemStorage, *Meta, *http.Response, error) { //nolint:dupl,lll
+	req, err := f.client.NewRequest(ctx, http.MethodGet, virtualFileSystemStoragePath, nil)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	newValues, err := query.Values(options)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	req.URL.RawQuery = newValues.Encode()
+
+	vfsStorages := new(virtualFileSystemStoragesBase)
+	resp, err := f.client.DoWithContext(ctx, req, vfsStorages)
+	if err != nil {
+		return nil, nil, resp, err
+	}
+
+	return vfsStorages.VFSs, vfsStorages.Meta, resp, nil
+}
+
+// Attach attaches a virtual file system storage to another instance.
+func (f *VirtualFileSystemStorageServiceHandler) Attach(ctx context.Context, vfsID, targetID string) (*VirtualFileSystemStorageAttachment, *http.Response, error) { //nolint:lll
+	uri := fmt.Sprintf("%s/%s/attachments/%s", virtualFileSystemStoragePath, vfsID, targetID)
+
+	req, err := f.client.NewRequest(ctx, http.MethodPut, uri, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	att := new(VirtualFileSystemStorageAttachment)
+	resp, err := f.client.DoWithContext(ctx, req, att)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	fmt.Printf("%v", resp)
+
+	return att, resp, err
+}
+
+// AttachmentGet retrieves the attachment of a virtual file system storage and
+// the attached instance.
+func (f *VirtualFileSystemStorageServiceHandler) AttachmentGet(ctx context.Context, vfsID, targetID string) (*VirtualFileSystemStorageAttachment, *http.Response, error) { //nolint:lll
+	uri := fmt.Sprintf("%s/%s/attachments/%s", virtualFileSystemStoragePath, vfsID, targetID)
+
+	req, err := f.client.NewRequest(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	att := new(VirtualFileSystemStorageAttachment)
+	resp, err := f.client.DoWithContext(ctx, req, att)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return att, resp, err
+}
+
+// Detach sends a delete request for an attachment of a virtual file system
+// storage and another instance.
+func (f *VirtualFileSystemStorageServiceHandler) Detach(ctx context.Context, vfsID, targetID string) error {
+	uri := fmt.Sprintf("%s/%s/attachments/%s", virtualFileSystemStoragePath, vfsID, targetID)
+
+	req, err := f.client.NewRequest(ctx, http.MethodDelete, uri, nil)
+	if err != nil {
+		return err
+	}
+
+	if _, err := f.client.DoWithContext(ctx, req, nil); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
This adds support for managing VFS storages.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?

### Testing instructions
You can emulate these test funcs to check each route available through the govultr library:
```go
func vfsList(ctx context.Context, client *govultr.Client) {
	vfss, _, _, err := client.VirtualFileSystemStorage.List(ctx, nil)
	if err != nil {
		fmt.Println(err)
		panic(err.Error())
	}

	fmt.Printf("%+v", vfss)
}

func vfsGet(ctx context.Context, client *govultr.Client) {
	id := "0ae69c69-0c46-4ab3-8601-c86a39b1026e"
	vfs, _, err := client.VirtualFileSystemStorage.Get(ctx, id)
	if err != nil {
		fmt.Println(err)
		panic(err.Error())
	}

	fmt.Printf("%+v", vfs)
}

func vfsCreate(ctx context.Context, client *govultr.Client) {
	vfs, _, err := client.VirtualFileSystemStorage.Create(ctx, &govultr.VirtualFileSystemStorageReq{
		Region: "ewr",
		Label:  "govultr-test",
		StorageSize: govultr.VirtualFileSystemStorageSize{
			SizeGB: 10,
		},
		DiskType: "nvme",
		Tags: []string{
			"test-vfs",
			"delete-after-testing",
		},
	})

	if err != nil {
		fmt.Println(err)
		panic(err.Error())
	}

	fmt.Printf("%+v", vfs)
}

func vfsUpdate(ctx context.Context, client *govultr.Client) {
	id := "0ae69c69-0c46-4ab3-8601-c86a39b1026e"
	vfs, _, err := client.VirtualFileSystemStorage.Update(ctx, id, &govultr.VirtualFileSystemStorageUpdateReq{
		Label: "govultr-test-upd",
		StorageSize: govultr.VirtualFileSystemStorageSize{
			SizeGB: 20,
		},
	})

	if err != nil {
		fmt.Println(err)
		panic(err.Error())
	}

	fmt.Printf("%+v", vfs)
}

func vfsDelete(ctx context.Context, client *govultr.Client) {
	id := "0ae69c69-0c46-4ab3-8601-c86a39b1026e"
	if err := client.VirtualFileSystemStorage.Delete(ctx, id); err != nil {
		fmt.Println(err)
		panic(err.Error())
	}
}

func vfsAttach(ctx context.Context, client *govultr.Client) {
	id := "0ae69c69-0c46-4ab3-8601-c86a39b1026e"
	targetID := "4f05ab05-a560-4bce-8158-7088aaf5de78"
	att, _, err := client.VirtualFileSystemStorage.Attach(ctx, id, targetID)
	if err != nil {
		fmt.Println(err)
		panic(err.Error())
	}

	fmt.Printf("%+v", att)
}

func vfsAttachmentList(ctx context.Context, client *govultr.Client) {
	id := "0ae69c69-0c46-4ab3-8601-c86a39b1026e"
	atts, _, err := client.VirtualFileSystemStorage.AttachmentList(ctx, id)
	if err != nil {
		fmt.Println(err)
		panic(err.Error())
	}

	fmt.Printf("%+v", atts)
}

func vfsAttachmentGet(ctx context.Context, client *govultr.Client) {
	id := "0ae69c69-0c46-4ab3-8601-c86a39b1026e"
	targetID := "4f05ab05-a560-4bce-8158-7088aaf5de78"
	att, _, err := client.VirtualFileSystemStorage.AttachmentGet(ctx, id, targetID)
	if err != nil {
		fmt.Println(err)
		panic(err.Error())
	}

	fmt.Printf("%+v", att)
}

func vfsDetach(ctx context.Context, client *govultr.Client) {
	id := "0ae69c69-0c46-4ab3-8601-c86a39b1026e"
	targetID := "4f05ab05-a560-4bce-8158-7088aaf5de78"
	if err := client.VirtualFileSystemStorage.Detach(ctx, id, targetID); err != nil {
		fmt.Println(err)
		panic(err.Error())
	}
}
