### PR TITLE
Remove deprecated Redis references

### DIFF
--- a/database.go
+++ b/database.go
@@ -103,9 +103,10 @@ type DatabasePlan struct {
 
 // SupportedEngines represents an object containing supported database engine types for Managed Database plans
 type SupportedEngines struct {
-	MySQL *bool `json:"mysql"`
-	PG    *bool `json:"pg"`
-	Redis *bool `json:"redis"`
+	MySQL  *bool `json:"mysql"`
+	PG     *bool `json:"pg"`
+	Valkey *bool `json:"valkey"`
+	Kafka  *bool `json:"kafka"`
 }
 
 // MaxConnections represents an object containing the maximum number of connections by engine type for Managed Database plans
@@ -163,11 +164,9 @@ type Database struct {
 	MySQLSlowQueryLog      *bool                `json:"mysql_slow_query_log,omitempty"`
 	MySQLLongQueryTime     int                  `json:"mysql_long_query_time,omitempty"`
 	PGAvailableExtensions  []PGExtension        `json:"pg_available_extensions,omitempty"`
-	// Deprecated: RedisEvictionPolicy should no longer be used. Instead, use EvictionPolicy
-	RedisEvictionPolicy string     `json:"redis_eviction_policy,omitempty"`
-	EvictionPolicy      string     `json:"eviction_policy,omitempty"`
-	ClusterTimeZone     string     `json:"cluster_time_zone,omitempty"`
-	ReadReplicas        []Database `json:"read_replicas,omitempty"`
+	EvictionPolicy         string               `json:"eviction_policy,omitempty"`
+	ClusterTimeZone        string               `json:"cluster_time_zone,omitempty"`
+	ReadReplicas           []Database           `json:"read_replicas,omitempty"`
 }
 
 // FerretDBCredentials represents connection details and IP address information for FerretDB engine type subscriptions
@@ -213,9 +212,7 @@ type DatabaseCreateReq struct {
 	MySQLRequirePrimaryKey *bool    `json:"mysql_require_primary_key,omitempty"`
 	MySQLSlowQueryLog      *bool    `json:"mysql_slow_query_log,omitempty"`
 	MySQLLongQueryTime     int      `json:"mysql_long_query_time,omitempty"`
-	// Deprecated: RedisEvictionPolicy should no longer be used. Instead, use EvictionPolicy
-	RedisEvictionPolicy string `json:"redis_eviction_policy,omitempty"`
-	EvictionPolicy      string `json:"eviction_policy,omitempty"`
+	EvictionPolicy         string   `json:"eviction_policy,omitempty"`
 }
 
 // DatabaseUpdateReq struct used to update a dataase.
@@ -233,9 +230,7 @@ type DatabaseUpdateReq struct {
 	MySQLRequirePrimaryKey *bool    `json:"mysql_require_primary_key,omitempty"`
 	MySQLSlowQueryLog      *bool    `json:"mysql_slow_query_log,omitempty"`
 	MySQLLongQueryTime     int      `json:"mysql_long_query_time,omitempty"`
-	// Deprecated: RedisEvictionPolicy should no longer be used. Instead, use EvictionPolicy
-	RedisEvictionPolicy string `json:"redis_eviction_policy,omitempty"`
-	EvictionPolicy      string `json:"eviction_policy,omitempty"`
+	EvictionPolicy         string   `json:"eviction_policy,omitempty"`
 }
 
 // DatabaseUsage represents disk, memory, and CPU usage for a Managed Database
@@ -280,16 +275,8 @@ type DatabaseUser struct {
 	AccessCert    string           `json:"access_cert,omitempty"`
 }
 
-// DatabaseUserACL represents an access control configuration for a user within a Redis Managed Database cluster
+// DatabaseUserACL represents an access control configuration for a user within a Valkey Managed Database cluster
 type DatabaseUserACL struct {
-	// Deprecated: RedisACLCategories should no longer be used. Instead, use ACLCategories
-	RedisACLCategories []string `json:"redis_acl_categories,omitempty"`
-	// Deprecated: RedisACLChannels should no longer be used. Instead, use ACLChannels
-	RedisACLChannels []string `json:"redis_acl_channels,omitempty"`
-	// Deprecated: RedisACLCommands should no longer be used. Instead, use ACLCommands
-	RedisACLCommands []string `json:"redis_acl_commands,omitempty"`
-	// Deprecated: RedisACLKeys should no longer be used. Instead, use ACLKeys
-	RedisACLKeys  []string `json:"redis_acl_keys,omitempty"`
 	ACLCategories []string `json:"acl_categories"`
 	ACLChannels   []string `json:"acl_channels"`
 	ACLCommands   []string `json:"acl_commands"`
@@ -298,14 +285,6 @@ type DatabaseUserACL struct {
 
 // DatabaseUserACLReq represents input for updating a user's access control within a Managed Database cluster
 type DatabaseUserACLReq struct {
-	// Deprecated: RedisACLCategories should no longer be used. Instead, use ACLCategories
-	RedisACLCategories *[]string `json:"redis_acl_categories,omitempty"`
-	// Deprecated: RedisACLChannels should no longer be used. Instead, use ACLChannels
-	RedisACLChannels *[]string `json:"redis_acl_channels,omitempty"`
-	// Deprecated: RedisACLCommands should no longer be used. Instead, use ACLCommands
-	RedisACLCommands *[]string `json:"redis_acl_commands,omitempty"`
-	// Deprecated: RedisACLKeys should no longer be used. Instead, use ACLKeys
-	RedisACLKeys  *[]string `json:"redis_acl_keys,omitempty"`
 	ACLCategories *[]string `json:"acl_categories,omitempty"`
 	ACLChannels   *[]string `json:"acl_channels,omitempty"`
 	ACLCommands   *[]string `json:"acl_commands,omitempty"`
@@ -932,7 +911,7 @@ func (d *DatabaseServiceHandler) DeleteUser(ctx context.Context, databaseID, use
 	return err
 }
 
-// UpdateUserACL will update a user's access control within the Redis Managed Database
+// UpdateUserACL will update a user's access control within the Valkey Managed Database
 func (d *DatabaseServiceHandler) UpdateUserACL(ctx context.Context, databaseID, username string, databaseUserACLReq *DatabaseUserACLReq) (*DatabaseUser, *http.Response, error) { //nolint:lll,dupl
 	uri := fmt.Sprintf("%s/%s/users/%s/access-control", databasePath, databaseID, username)
 


### PR DESCRIPTION
## Description
This PR removes previously-deprecated fields that were named specifically for Redis and cleans up a few other references (such as valid engine types for Managed Database plans). All services have been converted from Redis to Valkey, so the new, more generic-named fields should be used going forward.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
