### PR TITLE
Implements (and tests) `/account/bandwidth`

### DIFF
--- a/account.go
+++ b/account.go
@@ -31,7 +31,7 @@ type Account struct {
 	Email             string   `json:"email"`
 	ACL               []string `json:"acls"`
 }
-type AccountBandwidthBase struct {
+type accountBandwidthBase struct {
 	Bandwidth *AccountBandwidth `json:"bandwidth"`
 }
 
@@ -83,7 +83,7 @@ func (a *AccountServiceHandler) GetBandwidth(ctx context.Context) (*AccountBandw
 		return nil, nil, err
 	}
 
-	accountBandwidth := new(AccountBandwidthBase)
+	accountBandwidth := new(accountBandwidthBase)
 	resp, err := a.client.DoWithContext(ctx, req, accountBandwidth)
 	if err != nil {
 		return nil, resp, err

--- a/account.go
+++ b/account.go
@@ -9,6 +9,7 @@ import (
 // Link : https://www.vultr.com/api/#tag/account
 type AccountService interface {
 	Get(ctx context.Context) (*Account, *http.Response, error)
+	GetBandwidth(ctx context.Context) (*AccountBandwidth, *http.Response, error)
 }
 
 // AccountServiceHandler handles interaction with the account methods for the Vultr API
@@ -30,6 +31,32 @@ type Account struct {
 	Email             string   `json:"email"`
 	ACL               []string `json:"acls"`
 }
+type AccountBandwidthBase struct {
+	Bandwidth *AccountBandwidth `json:"bandwidth"`
+}
+
+// Bandwidth represents a Vultr account bandwidth
+type AccountBandwidth struct {
+	PreviousMonth         AccountBandwidthPeriod `json:"previous_month"`
+	CurrentMonthToDate    AccountBandwidthPeriod `json:"current_month_to_date"`
+	CurrentMonthProjected AccountBandwidthPeriod `json:"current_month_projected"`
+}
+
+// AccountBandwidthPeriod represents a Vultr account bandwidth period
+type AccountBandwidthPeriod struct {
+	TimestampStart            string  `json:"timestamp_start"`
+	TimestampEnd              string  `json:"timestamp_end"`
+	GbIn                      int     `json:"gb_in"`
+	GbOut                     int     `json:"gb_out"`
+	TotalInstanceHours        int     `json:"total_instance_hours"`
+	TotalInstanceCount        int     `json:"total_instance_count"`
+	InstanceBandwidthCredits  int     `json:"instance_bandwidth_credits"`
+	FreeBandwidthCredits      int     `json:"free_bandwidth_credits"`
+	PurchasedBandwidthCredits int     `json:"purchased_bandwidth_credits"`
+	Overage                   float32 `json:"overage"`
+	OverageUnitCost           float32 `json:"overage_unit_cost"`
+	OverageCost               float32 `json:"overage_cost"`
+}
 
 // Get Vultr account info
 func (a *AccountServiceHandler) Get(ctx context.Context) (*Account, *http.Response, error) {
@@ -46,4 +73,21 @@ func (a *AccountServiceHandler) Get(ctx context.Context) (*Account, *http.Respon
 	}
 
 	return account.Account, resp, nil
+}
+
+// Get Vultr account bandwidth info
+func (a *AccountServiceHandler) GetBandwidth(ctx context.Context) (*AccountBandwidth, *http.Response, error) {
+	uri := "/v2/account/bandwidth"
+	req, err := a.client.NewRequest(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	accountBandwidth := new(AccountBandwidthBase)
+	resp, err := a.client.DoWithContext(ctx, req, accountBandwidth)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return accountBandwidth.Bandwidth, resp, nil
 }

--- a/account.go
+++ b/account.go
@@ -46,8 +46,8 @@ type AccountBandwidth struct {
 type AccountBandwidthPeriod struct {
 	TimestampStart            string  `json:"timestamp_start"`
 	TimestampEnd              string  `json:"timestamp_end"`
-	GbIn                      int     `json:"gb_in"`
-	GbOut                     int     `json:"gb_out"`
+	GBIn                      int     `json:"gb_in"`
+	GBOut                     int     `json:"gb_out"`
 	TotalInstanceHours        int     `json:"total_instance_hours"`
 	TotalInstanceCount        int     `json:"total_instance_count"`
 	InstanceBandwidthCredits  int     `json:"instance_bandwidth_credits"`

--- a/account_test.go
+++ b/account_test.go
@@ -112,8 +112,8 @@ func TestAccountServiceHandler_GetBandwidth(t *testing.T) {
 		PreviousMonth: AccountBandwidthPeriod{
 			TimestampStart:            "1735689600",
 			TimestampEnd:              "1738367999",
-			GbIn:                      0,
-			GbOut:                     0,
+			GBIn:                      0,
+			GBOut:                     0,
 			TotalInstanceHours:        1,
 			TotalInstanceCount:        1,
 			InstanceBandwidthCredits:  1,
@@ -126,8 +126,8 @@ func TestAccountServiceHandler_GetBandwidth(t *testing.T) {
 		CurrentMonthToDate: AccountBandwidthPeriod{
 			TimestampStart:            "1738368000",
 			TimestampEnd:              "1739577600",
-			GbIn:                      0,
-			GbOut:                     0,
+			GBIn:                      0,
+			GBOut:                     0,
 			TotalInstanceHours:        0,
 			TotalInstanceCount:        0,
 			InstanceBandwidthCredits:  0,
@@ -140,8 +140,8 @@ func TestAccountServiceHandler_GetBandwidth(t *testing.T) {
 		CurrentMonthProjected: AccountBandwidthPeriod{
 			TimestampStart:            "1738368000",
 			TimestampEnd:              "1740787199",
-			GbIn:                      0,
-			GbOut:                     0,
+			GBIn:                      0,
+			GBOut:                     0,
 			TotalInstanceHours:        0,
 			TotalInstanceCount:        0,
 			InstanceBandwidthCredits:  0,

--- a/account_test.go
+++ b/account_test.go
@@ -45,3 +45,115 @@ func TestAccountServiceHandler_Get(t *testing.T) {
 		t.Errorf("Account.Get returned %+v, expected %+v", account, expected)
 	}
 }
+
+func TestAccountServiceHandler_GetBandwidth(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/account/bandwidth", func(w http.ResponseWriter, r *http.Request) {
+		response := `
+		{
+			"bandwidth": {
+				"previous_month": {
+					"timestamp_start": "1735689600",
+					"timestamp_end": "1738367999",
+					"gb_in": 0,
+					"gb_out": 0,
+					"total_instance_hours": 1,
+					"total_instance_count": 1,
+					"instance_bandwidth_credits": 1,
+					"free_bandwidth_credits": 2048,
+					"purchased_bandwidth_credits": 0,
+					"overage": 0,
+					"overage_unit_cost": 0.01,
+					"overage_cost": 0
+				},
+				"current_month_to_date": {
+					"timestamp_start": "1738368000",
+					"timestamp_end": "1739577600",
+					"gb_in": 0,
+					"gb_out": 0,
+					"total_instance_hours": 0,
+					"total_instance_count": 0,
+					"instance_bandwidth_credits": 0,
+					"free_bandwidth_credits": 2048,
+					"purchased_bandwidth_credits": 0,
+					"overage": 0,
+					"overage_unit_cost": 0.01,
+					"overage_cost": 0
+				},
+				"current_month_projected": {
+					"timestamp_start": "1738368000",
+					"timestamp_end": "1740787199",
+					"gb_in": 0,
+					"gb_out": 0,
+					"total_instance_hours": 0,
+					"total_instance_count": 0,
+					"instance_bandwidth_credits": 0,
+					"free_bandwidth_credits": 2048,
+					"purchased_bandwidth_credits": 0,
+					"overage": 0,
+					"overage_unit_cost": 0.01,
+					"overage_cost": 0
+				}
+			}
+		}
+		`
+
+		fmt.Fprint(w, response)
+	})
+
+	accountBandwidth, _, err := client.Account.GetBandwidth(ctx)
+	if err != nil {
+		t.Errorf("Account.GetBandwidth returned error: %v", err)
+	}
+
+	expected := &AccountBandwidth{
+		PreviousMonth: AccountBandwidthPeriod{
+			TimestampStart:            "1735689600",
+			TimestampEnd:              "1738367999",
+			GbIn:                      0,
+			GbOut:                     0,
+			TotalInstanceHours:        1,
+			TotalInstanceCount:        1,
+			InstanceBandwidthCredits:  1,
+			FreeBandwidthCredits:      2048,
+			PurchasedBandwidthCredits: 0,
+			Overage:                   0,
+			OverageUnitCost:           0.01,
+			OverageCost:               0,
+		},
+		CurrentMonthToDate: AccountBandwidthPeriod{
+			TimestampStart:            "1738368000",
+			TimestampEnd:              "1739577600",
+			GbIn:                      0,
+			GbOut:                     0,
+			TotalInstanceHours:        0,
+			TotalInstanceCount:        0,
+			InstanceBandwidthCredits:  0,
+			FreeBandwidthCredits:      2048,
+			PurchasedBandwidthCredits: 0,
+			Overage:                   0,
+			OverageUnitCost:           0.01,
+			OverageCost:               0,
+		},
+		CurrentMonthProjected: AccountBandwidthPeriod{
+			TimestampStart:            "1738368000",
+			TimestampEnd:              "1740787199",
+			GbIn:                      0,
+			GbOut:                     0,
+			TotalInstanceHours:        0,
+			TotalInstanceCount:        0,
+			InstanceBandwidthCredits:  0,
+			FreeBandwidthCredits:      2048,
+			PurchasedBandwidthCredits: 0,
+			Overage:                   0,
+			OverageUnitCost:           0.01,
+			OverageCost:               0,
+		},
+	}
+
+	if !reflect.DeepEqual(accountBandwidth, expected) {
+		t.Errorf("Account.GetBandwidth returned %+v, expected %+v", accountBandwidth, expected)
+	}
+}


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->

Implements for [`/account/bandwidth`](https://www.vultr.com/api/#tag/account/operation/get-account-bandwidth) to `govultr`.

The implementation requires a type corresponding to JSON of e.g. this form:

```JSON
{
	"bandwidth": {
		"previous_month": {
			"timestamp_start": "1735689600",
			"timestamp_end": "1738367999",
			"gb_in": 0,
			"gb_out": 0,
			"total_instance_hours": 1,
			"total_instance_count": 1,
			"instance_bandwidth_credits": 1,
			"free_bandwidth_credits": 2048,
			"purchased_bandwidth_credits": 0,
			"overage": 0,
			"overage_unit_cost": 0.01,
			"overage_cost": 0
		},
		"current_month_to_date": {
			"timestamp_start": "1738368000",
			"timestamp_end": "1739577600",
			"gb_in": 0,
			"gb_out": 0,
			"total_instance_hours": 0,
			"total_instance_count": 0,
			"instance_bandwidth_credits": 0,
			"free_bandwidth_credits": 2048,
			"purchased_bandwidth_credits": 0,
			"overage": 0,
			"overage_unit_cost": 0.01,
			"overage_cost": 0
		},
		"current_month_projected": {
			"timestamp_start": "1738368000",
			"timestamp_end": "1740787199",
			"gb_in": 0,
			"gb_out": 0,
			"total_instance_hours": 0,
			"total_instance_count": 0,
			"instance_bandwidth_credits": 0,
			"free_bandwidth_credits": 2048,
			"purchased_bandwidth_credits": 0,
			"overage": 0,
			"overage_unit_cost": 0.01,
			"overage_cost": 0
		}
	}
}
```

The type for `bandwidth` could be represented either a struct or map. A map could promote iterative handling but is less accurate representation of the type.

I've named types `AccountBandwidth(Base)` and `AccountBandwidthPeriod`  as I was unable to find exemplars elsewhere in the code and `Bandwidth` is taken (used by `Instance`) and different.

I've also assumed types (`int` and `float32`) for the properties as I was unable to find these types documented elsewhere.

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

Fixes #354

### Checklist:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [X] Have you linted your code locally prior to submission?
* [X] Have you successfully ran tests with your changes locally?
