### PR TITLE
Add go doc deprecation for VPC2 service and structs

### DIFF
--- a/govultr.go
+++ b/govultr.go
@@ -72,7 +72,8 @@ type Client struct {
 	User                     UserService
 	VirtualFileSystemStorage VirtualFileSystemStorageService
 	VPC                      VPCService
-	VPC2                     VPC2Service
+	// Deprecated: VPC2 is no longer supported
+	VPC2 VPC2Service
 
 	// Optional function called after every successful request made to the Vultr API
 	onRequestCompleted RequestCompletionCallback

--- a/vpc2.go
+++ b/vpc2.go
@@ -12,14 +12,24 @@ const vpc2Path = "/v2/vpc2"
 
 // VPC2Service is the interface to interact with the VPC 2.0 endpoints on the Vultr API
 // Link : https://www.vultr.com/api/#tag/vpc2
+// Deprecated: VPC2 is no longer supported and functionality will cease in a
+// future release
 type VPC2Service interface {
+	// Deprecated: VPC2 is no longer supported
 	Create(ctx context.Context, createReq *VPC2Req) (*VPC2, *http.Response, error)
+	// Deprecated: VPC2 is no longer supported
 	Get(ctx context.Context, vpcID string) (*VPC2, *http.Response, error)
+	// Deprecated: VPC2 is no longer supported
 	Update(ctx context.Context, vpcID string, description string) error
+	// Deprecated: VPC2 is no longer supported
 	Delete(ctx context.Context, vpcID string) error
+	// Deprecated: VPC2 is no longer supported
 	List(ctx context.Context, options *ListOptions) ([]VPC2, *Meta, *http.Response, error)
+	// Deprecated: VPC2 is no longer supported
 	ListNodes(ctx context.Context, vpc2ID string, options *ListOptions) ([]VPC2Node, *Meta, *http.Response, error)
+	// Deprecated: VPC2 is no longer supported
 	Attach(ctx context.Context, vpcID string, attachReq *VPC2AttachDetachReq) error
+	// Deprecated: VPC2 is no longer supported
 	Detach(ctx context.Context, vpcID string, detachReq *VPC2AttachDetachReq) error
 }
 
@@ -29,6 +39,8 @@ type VPC2ServiceHandler struct {
 }
 
 // VPC2 represents a Vultr VPC 2.0
+// Deprecated: VPC2 is no longer supported and functionality will cease in a
+// future release
 type VPC2 struct {
 	ID           string `json:"id"`
 	Region       string `json:"region"`
@@ -77,6 +89,8 @@ type vpc2NodesBase struct {
 }
 
 // Create creates a new VPC 2.0. A VPC 2.0 can only be used at the location for which it was created.
+// Deprecated: VPC2 is no longer supported and functionality will cease in a
+// future release
 func (n *VPC2ServiceHandler) Create(ctx context.Context, createReq *VPC2Req) (*VPC2, *http.Response, error) {
 	req, err := n.client.NewRequest(ctx, http.MethodPost, vpc2Path, createReq)
 	if err != nil {
@@ -93,6 +107,8 @@ func (n *VPC2ServiceHandler) Create(ctx context.Context, createReq *VPC2Req) (*V
 }
 
 // Get gets the VPC 2.0 of the requested ID
+// Deprecated: VPC2 is no longer supported and functionality will cease in a
+// future release
 func (n *VPC2ServiceHandler) Get(ctx context.Context, vpcID string) (*VPC2, *http.Response, error) {
 	uri := fmt.Sprintf("%s/%s", vpc2Path, vpcID)
 	req, err := n.client.NewRequest(ctx, http.MethodGet, uri, nil)
@@ -110,6 +126,8 @@ func (n *VPC2ServiceHandler) Get(ctx context.Context, vpcID string) (*VPC2, *htt
 }
 
 // Update updates a VPC 2.0
+// Deprecated: VPC2 is no longer supported and functionality will cease in a
+// future release
 func (n *VPC2ServiceHandler) Update(ctx context.Context, vpcID, description string) error {
 	uri := fmt.Sprintf("%s/%s", vpc2Path, vpcID)
 
@@ -124,6 +142,8 @@ func (n *VPC2ServiceHandler) Update(ctx context.Context, vpcID, description stri
 }
 
 // Delete deletes a VPC 2.0. Before deleting, a VPC 2.0 must be disabled from all instances
+// Deprecated: VPC2 is no longer supported and functionality will cease in a
+// future release
 func (n *VPC2ServiceHandler) Delete(ctx context.Context, vpcID string) error {
 	uri := fmt.Sprintf("%s/%s", vpc2Path, vpcID)
 	req, err := n.client.NewRequest(ctx, http.MethodDelete, uri, nil)
@@ -135,6 +155,8 @@ func (n *VPC2ServiceHandler) Delete(ctx context.Context, vpcID string) error {
 }
 
 // List lists all VPCs 2.0 on the current account
+// Deprecated: VPC2 is no longer supported and functionality will cease in a
+// future release
 func (n *VPC2ServiceHandler) List(ctx context.Context, options *ListOptions) ([]VPC2, *Meta, *http.Response, error) { //nolint:dupl
 	req, err := n.client.NewRequest(ctx, http.MethodGet, vpc2Path, nil)
 	if err != nil {
@@ -158,6 +180,8 @@ func (n *VPC2ServiceHandler) List(ctx context.Context, options *ListOptions) ([]
 }
 
 // ListNodes lists all nodes attached to a VPC 2.0 network
+// Deprecated: VPC2 is no longer supported and functionality will cease in a
+// future release
 func (n *VPC2ServiceHandler) ListNodes(ctx context.Context, vpc2ID string, options *ListOptions) ([]VPC2Node, *Meta, *http.Response, error) { //nolint:dupl,lll
 	uri := fmt.Sprintf("%s/%s/nodes", vpc2Path, vpc2ID)
 
@@ -183,6 +207,8 @@ func (n *VPC2ServiceHandler) ListNodes(ctx context.Context, vpc2ID string, optio
 }
 
 // Attach attaches nodes to a VPC 2.0 network
+// Deprecated: VPC2 is no longer supported and functionality will cease in a
+// future release
 func (n *VPC2ServiceHandler) Attach(ctx context.Context, vpcID string, attachReq *VPC2AttachDetachReq) error {
 	uri := fmt.Sprintf("%s/%s/nodes/attach", vpc2Path, vpcID)
 
@@ -196,6 +222,8 @@ func (n *VPC2ServiceHandler) Attach(ctx context.Context, vpcID string, attachReq
 }
 
 // Detach detaches nodes from a VPC 2.0 network
+// Deprecated: VPC2 is no longer supported and functionality will cease in a
+// future release
 func (n *VPC2ServiceHandler) Detach(ctx context.Context, vpcID string, detachReq *VPC2AttachDetachReq) error {
 	uri := fmt.Sprintf("%s/%s/nodes/detach", vpc2Path, vpcID)
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
VPC2 is being deprecated.  This annotates the services and structs with that notice.

### Checklist:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you linted your code locally prior to submission?
* [ ] Have you successfully ran tests with your changes locally?
