### PR TITLE
snapshots: Add support for CreateFromURL UEFI field

### DIFF
--- a/snapshot.go
+++ b/snapshot.go
@@ -45,6 +45,7 @@ type SnapshotReq struct {
 type SnapshotURLReq struct {
 	URL         string `json:"url"`
 	Description string `json:"description,omitempty"`
+	UEFI        *bool  `json:"uefi"`
 }
 
 type snapshotsBase struct {


### PR DESCRIPTION
NOTE: This field was historically a string which took `""`, `"no"`, or `"yes"`. The API has recently
been updated to take `true` and `false` booleans.

This adds the field as a `*bool` so that we can differentiate unset vs explicitly false.

Based on the current unit test setup, there isn't much point in adding coverage for this field.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?

Updated unit tests, and tested e2e manually with a corresponding update to the CLI: https://github.com/vultr/vultr-cli/pull/547
