### PR TITLE
Update Inference image usage fields to floats instead of ints

### DIFF
--- a/inference.go
+++ b/inference.go
@@ -70,8 +70,8 @@ type InferenceAudioUsage struct {
 
 // InferenceImageUsage represents image generation details for a Serverless Inference subscription
 type InferenceImageUsage struct {
-	Megapixels   int `json:"megapixels"`
-	SMMegapixels int `json:"sm_megapixels"`
+	Megapixels   float32 `json:"megapixels"`
+	SMMegapixels float32 `json:"sm_megapixels"`
 }
 
 // InferenceChatUsage represents chat/embeddings usage details for a Serverless Inference subscription


### PR DESCRIPTION
## Description
Fixes incorrect data types for `InferenceImageUsage` struct fields.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
