### PR TITLE
Remove member count on org group

### DIFF
--- a/organization.go
+++ b/organization.go
@@ -188,7 +188,6 @@ type OrganizationGroup struct {
 	ID           string             `json:"id"`
 	Name         string             `json:"display_name"`
 	Description  string             `json:"description"`
-	MemberCount  int                `json:"member_count,omitempty"`
 	Members      []OrganizationUser `json:"members"`
 	DateCreated  string             `json:"date_created"`
 	DateAssigned string             `json:"assigned_date,omitempty"`


### PR DESCRIPTION
The field no longer exists in the API

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
Remove a now defunct field from the organization group struct.  This field appears to be causing marshalling errors and no longer is supported by the API.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
