### PR TITLE
Fix invalid nil interface check on NewRequest

### DIFF
--- a/govultr.go
+++ b/govultr.go
@@ -289,7 +289,7 @@ func isNilInterface(i interface{}) bool {
 	}
 
 	switch v.Kind() {
-	case reflect.Ptr, reflect.Slice, reflect.Map, reflect.Func, reflect.Interface:
+	case reflect.Pointer, reflect.Slice, reflect.Map, reflect.Func, reflect.Interface:
 		return v.IsNil()
 	default:
 		return false

--- a/govultr.go
+++ b/govultr.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"reflect"
 	"strings"
 	"time"
 
@@ -166,8 +167,8 @@ func (c *Client) NewRequest(ctx context.Context, method, uri string, body interf
 		return nil, err
 	}
 
-	buf := new(bytes.Buffer)
-	if body != nil {
+	buf := &bytes.Buffer{}
+	if !reflect.ValueOf(body).IsNil() {
 		if err2 := json.NewEncoder(buf).Encode(body); err2 != nil {
 			return nil, err2
 		}

--- a/govultr.go
+++ b/govultr.go
@@ -168,7 +168,7 @@ func (c *Client) NewRequest(ctx context.Context, method, uri string, body interf
 	}
 
 	buf := &bytes.Buffer{}
-	if !reflect.ValueOf(body).IsNil() {
+	if !isNilInterface(body) {
 		if err2 := json.NewEncoder(buf).Encode(body); err2 != nil {
 			return nil, err2
 		}
@@ -279,6 +279,21 @@ func (c *Client) vultrErrorHandler(resp *http.Response, err error, numTries int)
 		return nil, fmt.Errorf("gave up after %d attempts, last error unavailable (error reading response body: %v)", numTries, err)
 	}
 	return nil, fmt.Errorf("gave up after %d attempts, last error: %#v", numTries, strings.TrimSpace(string(buf)))
+}
+
+func isNilInterface(i interface{}) bool {
+	v := reflect.ValueOf(i)
+
+	if !v.IsValid() {
+		return true
+	}
+
+	switch v.Kind() {
+	case reflect.Ptr, reflect.Slice, reflect.Map, reflect.Func, reflect.Interface:
+		return v.IsNil()
+	default:
+		return false
+	}
 }
 
 // BoolToBoolPtr helper function that returns a pointer from your bool value

--- a/govultr.go
+++ b/govultr.go
@@ -160,7 +160,7 @@ func NewClient(httpClient *http.Client) *Client {
 	return client
 }
 
-// NewRequest creates an API Request
+// NewRequest creates an API request
 func (c *Client) NewRequest(ctx context.Context, method, uri string, body interface{}) (*http.Request, error) {
 	resolvedURL, err := c.BaseURL.Parse(uri)
 	if err != nil {
@@ -186,9 +186,10 @@ func (c *Client) NewRequest(ctx context.Context, method, uri string, body interf
 	return req, nil
 }
 
-// DoWithContext sends an API Request and returns back the response. The API response is checked  to see if it was
-// a successful call. A successful call is then checked to see if we need to unmarshal since some resources
-// have their own implements of unmarshal.
+// DoWithContext sends an API request and returns back the response. The API
+// response is checked to see if it was a successful call. A successful call is
+// then checked to see if we need to unmarshal since some resources have their
+// own implements of unmarshal.
 func (c *Client) DoWithContext(ctx context.Context, r *http.Request, data interface{}) (*http.Response, error) {
 	rreq, err := retryablehttp.FromRequest(r)
 	if err != nil {


### PR DESCRIPTION

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
The nil check when building the request body from the interface in `NewRequest` will always pass, even when the interface is nil. 

Interfaces must be opened in order to check if nil. The issue meant that the JSON marshaler would always output 'null' when a nil interface was passed in to NewRequest.

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
