### PR TITLE
Add vpc_only to kubernetes node pools

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -84,6 +84,7 @@ type NodePool struct {
 	AutoScaler   bool              `json:"auto_scaler"`
 	UserData     string            `json:"user_data"`
 	Tag          string            `json:"tag"`
+	VPCOnly      bool              `json:"vpc_only"`
 	Labels       map[string]string `json:"labels"`
 	Taints       []Taint           `json:"taints"`
 	Nodes        []Node            `json:"nodes"`
@@ -130,6 +131,7 @@ type NodePoolReq struct {
 	MinNodes     int               `json:"min_nodes,omitempty"`
 	MaxNodes     int               `json:"max_nodes,omitempty"`
 	AutoScaler   *bool             `json:"auto_scaler"`
+	VPCOnly      *bool             `json:"vpc_only,omitempty"`
 	Labels       map[string]string `json:"labels,omitempty"`
 	Taints       []Taint           `json:"taints,omitempty"`
 	UserData     string            `json:"user_data"`

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -378,6 +378,7 @@ func TestKubernetesHandler_CreateNodePool(t *testing.T) {
 		"max_nodes": 2,
 		"auto_scaler": true,
 		"tag": "mytag",
+		"vpc_only": true,
 		"labels": {
 			"vultr.com/label1": "value1",
 			"vultr.com/label2": "value2"
@@ -407,6 +408,7 @@ func TestKubernetesHandler_CreateNodePool(t *testing.T) {
 		Label:        "nodepool-48959140",
 		Plan:         "vc2-1c-2gb",
 		Tag:          "mytag",
+		VPCOnly:      BoolToBoolPtr(true),
 		Labels: map[string]string{
 			"vultr.com/label1": "value1",
 			"vultr.com/label2": "value2",
@@ -435,6 +437,7 @@ func TestKubernetesHandler_CreateNodePool(t *testing.T) {
 		MaxNodes:     2,
 		AutoScaler:   true,
 		Tag:          "mytag",
+		VPCOnly:      true,
 		Labels: map[string]string{
 			"vultr.com/label1": "value1",
 			"vultr.com/label2": "value2",


### PR DESCRIPTION
Adds the `VPCOnly` field to `NodePoolReq` and `NodePool`, matching the `vpc_only` field in the VKE API for creating node pools without public IPs (egress via the VPC NAT Gateway).

API reference: https://docs.vultr.com/how-to-deploy-a-vpc-only-vultr-kubernetes-engine-with-nat-gateway