### PR TITLE
Branch DoWithContext response parsing on status code

### DIFF
--- a/govultr.go
+++ b/govultr.go
@@ -227,7 +227,7 @@ func (c *Client) DoWithContext(ctx context.Context, r *http.Request, data interf
 			return res, nil
 		}
 
-		switch res.Header.Get("Content-Type") {
+		switch res.Header.Get("Content-Type") { //nolint:gocritic
 		case "application/json":
 			if err := json.Unmarshal(body, data); err != nil {
 				return nil, err

--- a/govultr.go
+++ b/govultr.go
@@ -221,16 +221,27 @@ func (c *Client) DoWithContext(ctx context.Context, r *http.Request, data interf
 
 	res.Body = io.NopCloser(bytes.NewBuffer(body))
 
-	if res.StatusCode >= http.StatusOK && res.StatusCode <= http.StatusNoContent {
-		if data != nil {
+	switch res.StatusCode {
+	case http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNonAuthoritativeInfo, http.StatusPartialContent:
+		if res.ContentLength == 0 || isNilInterface(data) {
+			return res, nil
+		}
+
+		switch res.Header.Get("Content-Type") {
+		case "application/json":
 			if err := json.Unmarshal(body, data); err != nil {
 				return nil, err
 			}
 		}
-		return res, nil
-	}
 
-	return res, errors.New(string(body))
+		return res, nil
+
+	case http.StatusNoContent, http.StatusResetContent:
+		return res, nil
+
+	default:
+		return res, errors.New(string(body))
+	}
 }
 
 // SetBaseURL Overrides the default BaseUrl


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
DoWithContext will behave differently depending on the http status code returned from the API. Response codes that do no allow a body will no longer attempt to unmarshal a body.

Fixes an invalid interface nil check.

These changes also prepare the client for the ability to parse non-JSON response bodies, YAML being the content type needed for a few API endpoints.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
